### PR TITLE
chore: add Kodiak

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["renovate"]
+
+[approve]
+auto_approve_usernames = ["renovate"]


### PR DESCRIPTION
Configures Kodiak for this repo.

This lets you add an `automerge` label to PRs, and have Kodiak queue them for merging once all relevant conditions are met.
Kodiak will also keep the PR up to date with the default branch.