### PR TITLE
chore: switch to `next@latest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "husky": "^4.3.0",
         "jest": "^27.0.0",
         "netlify-plugin-cypress": "^2.2.0",
-        "next": "^11.1.3-canary.70",
+        "next": "^11.1.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.1.2",
         "react": "^17.0.1",
@@ -2620,9 +2620,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3-canary.70.tgz",
-      "integrity": "sha512-O+rVvWQITpNd+SP7eaRvO9Ff9q+7PbRsu4jsPUWpZaLt2o7/6yZ5SlfNpEA2ydmr+HXqLaqPOYV/N9We8r2U8Q==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
+      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==",
       "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2655,15 +2655,15 @@
       }
     },
     "node_modules/@next/polyfill-module": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3-canary.70.tgz",
-      "integrity": "sha512-w4/Vl0O1yQeZK9xLcb+eXyIQbSUn8yXOAAeSNj0ZoO3C2jx6uJFSv0T6Kciauv+fkgl9iA8b4T8IlAy7u+TdnA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
+      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA==",
       "dev": true
     },
     "node_modules/@next/react-dev-overlay": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3-canary.70.tgz",
-      "integrity": "sha512-ZozIn1cqCYFAsIkDC+1JC/cPdK+KoX68uOyxacORA9IPbivUvfEvwWG+FJ0H8XRupwQWcUxdzwnDS9ZzL/2Gog==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
+      "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -2676,7 +2676,7 @@
         "shell-quote": "1.7.2",
         "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "0.1.10",
-        "strip-ansi": "6.0.1"
+        "strip-ansi": "6.0.0"
       },
       "peerDependencies": {
         "react": "^17.0.2",
@@ -2729,6 +2729,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@next/react-dev-overlay/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@next/react-dev-overlay/node_modules/tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -2756,9 +2768,9 @@
       }
     },
     "node_modules/@next/react-refresh-utils": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3-canary.70.tgz",
-      "integrity": "sha512-8NypZjYfJu+qM3h46uxBaQQfFQH1xjSIP6aUyrcWApyGfsUhw3GBqvCnF2ciirw7/ObgeZ00ax7kCqnUCu6Fhg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
+      "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
       "dev": true,
       "peerDependencies": {
         "react-refresh": "0.8.3",
@@ -2771,9 +2783,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3-canary.70.tgz",
-      "integrity": "sha512-bSqDez6gNVNCIXJQKRXBdhT1bg8wVzotzhktlQQuTOX+s76jWtuK1FgkGKxV3c+dEK1+Z/qEZUSDxujT5nDMyw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
+      "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
       "cpu": [
         "arm64"
       ],
@@ -2787,9 +2799,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3-canary.70.tgz",
-      "integrity": "sha512-OFucQIhxPj1yy4ZGwK2OZMgakqRAeGBJWLRE3GV1iBrZfPSYQJBDFAHAFeOfdFcUXC/I6EYIuhX5Bw+D6uhoPA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
+      "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
       "cpu": [
         "x64"
       ],
@@ -2803,9 +2815,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3-canary.70.tgz",
-      "integrity": "sha512-k5ynEg03DnFuECNjXOsc6NSLztZO/CfAqiEb5tYJ9b2m7L7WJugwvDTlvpXSnfLGnLOcTCochLaykZlhbVwjlg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
+      "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
       "cpu": [
         "x64"
       ],
@@ -2819,9 +2831,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3-canary.70.tgz",
-      "integrity": "sha512-QTgOVzSP1b1fOdeXdTIZkbVQQu4eMWSNop8NeXWgVBifu2KdSOvb6E220+6Uolox8sfCipzLFy+jIpwkxLpRFA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
+      "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
       "cpu": [
         "x64"
       ],
@@ -3872,6 +3884,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
+      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ast-types-flow": {
@@ -13181,19 +13202,20 @@
       }
     },
     "node_modules/next": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.1.3-canary.70.tgz",
-      "integrity": "sha512-DejnicZmQnY69iGHeRZZlVhlYvRXfb15d+pI5Lq/SiA24WVMSv5dL6MMZjYv669Z/epn9s3BGbcxPLMrud/0qw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
+      "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "7.15.4",
+        "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.1.3-canary.70",
-        "@next/polyfill-module": "11.1.3-canary.70",
-        "@next/react-dev-overlay": "11.1.3-canary.70",
-        "@next/react-refresh-utils": "11.1.3-canary.70",
+        "@next/env": "11.1.2",
+        "@next/polyfill-module": "11.1.2",
+        "@next/react-dev-overlay": "11.1.2",
+        "@next/react-refresh-utils": "11.1.2",
         "@node-rs/helper": "1.2.1",
         "assert": "2.0.0",
+        "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
         "browserslist": "4.16.6",
         "buffer": "5.6.0",
@@ -13218,6 +13240,7 @@
         "os-browserify": "0.3.0",
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
+        "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.15",
         "process": "0.11.10",
         "querystring-es3": "0.2.1",
@@ -13227,7 +13250,7 @@
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
         "string_decoder": "1.3.0",
-        "styled-jsx": "5.0.0-beta.2",
+        "styled-jsx": "4.0.1",
         "timers-browserify": "2.0.12",
         "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
@@ -13242,14 +13265,14 @@
         "node": ">=12.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "11.1.3-canary.70",
-        "@next/swc-darwin-x64": "11.1.3-canary.70",
-        "@next/swc-linux-x64-gnu": "11.1.3-canary.70",
-        "@next/swc-win32-x64-msvc": "11.1.3-canary.70"
+        "@next/swc-darwin-arm64": "11.1.2",
+        "@next/swc-darwin-x64": "11.1.2",
+        "@next/swc-linux-x64-gnu": "11.1.2",
+        "@next/swc-win32-x64-msvc": "11.1.2"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "node-sass": "^4.0.0 || ^5.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "sass": "^1.3.0"
@@ -13264,6 +13287,18 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@babel/runtime": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/next/node_modules/ansi-styles": {
@@ -14727,6 +14762,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pnp-webpack-plugin": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+      "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+      "dev": true,
+      "dependencies": {
+        "ts-pnp": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/posix-character-classes": {
@@ -17081,9 +17128,9 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.2.tgz",
-      "integrity": "sha512-yDVSNs7o2TK1w2S+S1zMuAn2x7nuodg3jtcalfCIJasVtGMx3pziOEI2GR5OY2qrA6C9RaAAPQWl8DR7BvHcHg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.1.tgz",
+      "integrity": "sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-syntax-jsx": "7.14.5",
@@ -17598,6 +17645,20 @@
       },
       "peerDependencies": {
         "typescript": ">=2.7"
+      }
+    },
+    "node_modules/ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -20516,9 +20577,9 @@
       }
     },
     "@next/env": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3-canary.70.tgz",
-      "integrity": "sha512-O+rVvWQITpNd+SP7eaRvO9Ff9q+7PbRsu4jsPUWpZaLt2o7/6yZ5SlfNpEA2ydmr+HXqLaqPOYV/N9We8r2U8Q==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
+      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==",
       "dev": true
     },
     "@next/eslint-plugin-next": {
@@ -20547,15 +20608,15 @@
       }
     },
     "@next/polyfill-module": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3-canary.70.tgz",
-      "integrity": "sha512-w4/Vl0O1yQeZK9xLcb+eXyIQbSUn8yXOAAeSNj0ZoO3C2jx6uJFSv0T6Kciauv+fkgl9iA8b4T8IlAy7u+TdnA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
+      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA==",
       "dev": true
     },
     "@next/react-dev-overlay": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3-canary.70.tgz",
-      "integrity": "sha512-ZozIn1cqCYFAsIkDC+1JC/cPdK+KoX68uOyxacORA9IPbivUvfEvwWG+FJ0H8XRupwQWcUxdzwnDS9ZzL/2Gog==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
+      "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -20568,7 +20629,7 @@
         "shell-quote": "1.7.2",
         "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "0.1.10",
-        "strip-ansi": "6.0.1"
+        "strip-ansi": "6.0.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -20605,6 +20666,15 @@
             "whatwg-url": "^7.0.0"
           }
         },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
         "tr46": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -20634,37 +20704,37 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3-canary.70.tgz",
-      "integrity": "sha512-8NypZjYfJu+qM3h46uxBaQQfFQH1xjSIP6aUyrcWApyGfsUhw3GBqvCnF2ciirw7/ObgeZ00ax7kCqnUCu6Fhg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
+      "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
       "dev": true,
       "requires": {}
     },
     "@next/swc-darwin-arm64": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3-canary.70.tgz",
-      "integrity": "sha512-bSqDez6gNVNCIXJQKRXBdhT1bg8wVzotzhktlQQuTOX+s76jWtuK1FgkGKxV3c+dEK1+Z/qEZUSDxujT5nDMyw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
+      "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
       "dev": true,
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3-canary.70.tgz",
-      "integrity": "sha512-OFucQIhxPj1yy4ZGwK2OZMgakqRAeGBJWLRE3GV1iBrZfPSYQJBDFAHAFeOfdFcUXC/I6EYIuhX5Bw+D6uhoPA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
+      "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
       "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3-canary.70.tgz",
-      "integrity": "sha512-k5ynEg03DnFuECNjXOsc6NSLztZO/CfAqiEb5tYJ9b2m7L7WJugwvDTlvpXSnfLGnLOcTCochLaykZlhbVwjlg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
+      "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
       "dev": true,
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3-canary.70.tgz",
-      "integrity": "sha512-QTgOVzSP1b1fOdeXdTIZkbVQQu4eMWSNop8NeXWgVBifu2KdSOvb6E220+6Uolox8sfCipzLFy+jIpwkxLpRFA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
+      "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
       "dev": true,
       "optional": true
     },
@@ -21475,6 +21545,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
+      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
       "dev": true
     },
     "ast-types-flow": {
@@ -28665,23 +28741,24 @@
       }
     },
     "next": {
-      "version": "11.1.3-canary.70",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.1.3-canary.70.tgz",
-      "integrity": "sha512-DejnicZmQnY69iGHeRZZlVhlYvRXfb15d+pI5Lq/SiA24WVMSv5dL6MMZjYv669Z/epn9s3BGbcxPLMrud/0qw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
+      "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.15.4",
+        "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.1.3-canary.70",
-        "@next/polyfill-module": "11.1.3-canary.70",
-        "@next/react-dev-overlay": "11.1.3-canary.70",
-        "@next/react-refresh-utils": "11.1.3-canary.70",
-        "@next/swc-darwin-arm64": "11.1.3-canary.70",
-        "@next/swc-darwin-x64": "11.1.3-canary.70",
-        "@next/swc-linux-x64-gnu": "11.1.3-canary.70",
-        "@next/swc-win32-x64-msvc": "11.1.3-canary.70",
+        "@next/env": "11.1.2",
+        "@next/polyfill-module": "11.1.2",
+        "@next/react-dev-overlay": "11.1.2",
+        "@next/react-refresh-utils": "11.1.2",
+        "@next/swc-darwin-arm64": "11.1.2",
+        "@next/swc-darwin-x64": "11.1.2",
+        "@next/swc-linux-x64-gnu": "11.1.2",
+        "@next/swc-win32-x64-msvc": "11.1.2",
         "@node-rs/helper": "1.2.1",
         "assert": "2.0.0",
+        "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
         "browserslist": "4.16.6",
         "buffer": "5.6.0",
@@ -28706,6 +28783,7 @@
         "os-browserify": "0.3.0",
         "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
+        "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.15",
         "process": "0.11.10",
         "querystring-es3": "0.2.1",
@@ -28715,7 +28793,7 @@
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
         "string_decoder": "1.3.0",
-        "styled-jsx": "5.0.0-beta.2",
+        "styled-jsx": "4.0.1",
         "timers-browserify": "2.0.12",
         "tty-browserify": "0.0.1",
         "use-subscription": "1.5.1",
@@ -28724,6 +28802,15 @@
         "watchpack": "2.1.1"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -29882,6 +29969,15 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
+    },
+    "pnp-webpack-plugin": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+      "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+      "dev": true,
+      "requires": {
+        "ts-pnp": "^1.1.6"
+      }
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -31765,9 +31861,9 @@
       "dev": true
     },
     "styled-jsx": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.2.tgz",
-      "integrity": "sha512-yDVSNs7o2TK1w2S+S1zMuAn2x7nuodg3jtcalfCIJasVtGMx3pziOEI2GR5OY2qrA6C9RaAAPQWl8DR7BvHcHg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.1.tgz",
+      "integrity": "sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-jsx": "7.14.5",
@@ -32181,6 +32277,12 @@
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       }
+    },
+    "ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "husky": "^4.3.0",
     "jest": "^27.0.0",
     "netlify-plugin-cypress": "^2.2.0",
-    "next": "^11.1.3-canary.70",
+    "next": "^11.1.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "react": "^17.0.1",


### PR DESCRIPTION
We already run extra tests on `next@canary`, so the main build should be on `next@latest`