### PR TITLE
fix: pass query string to handler

### DIFF
--- a/src/templates/getHandler.js
+++ b/src/templates/getHandler.js
@@ -49,6 +49,10 @@ const makeHandler =
     bridge.listen()
 
     return async (event, context) => {
+      // Next expects to be able to parse the query from the URL
+      const query = new URLSearchParams(event.queryStringParameters).toString()
+      event.path = query ? `${event.path}?${query}` : event.path
+
       const { headers, ...result } = await bridge.launcher(event, context)
       /** @type import("@netlify/functions").HandlerResponse */
 


### PR DESCRIPTION
Next server's query middleware expects the URL query params to be in the path

Fixes https://github.com/netlify/netlify-plugin-nextjs/discussions/706#discussioncomment-1490381