### PR TITLE
chore: add docs and log links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ publish = ".next"
 package = "@netlify/plugin-nextjs"
 ```
 
-If you previously set `target: "serverless"`, `node_bundler` or `external_node_modules` in your `next.config.js` these are no longer needed and can be removed.
+If you previously set `target: "serverless"` or a custom `distDir` in your `next.config.js`, or set `node_bundler` or `external_node_modules` in your `netlify.toml` these are no longer needed and can be removed.
+
+If you are using a monorepo you will need to change `publish` to point to the full path to the built `.next` directory, which may be in a subdirectory. If you have changed your `distDir` then it will need to match that. 
+
+If you are using Nx, then you will need to point `publish` to the folder inside `dist`, e.g. `dist/apps/myapp/.next`. 
 
 ## Beta feedback
 

--- a/docs/large-functions.md
+++ b/docs/large-functions.md
@@ -1,0 +1,16 @@
+## Troubleshooting large functions
+
+You may see an error about generated functions being too large. This is because when deploying your site it is packaged into a zipfile, which is limited by AWS to 50MB in size. 
+There are two possible causes for this, each with its own solution. The list of largest files shown in the build logs will help you see what the cause is.
+
+- **Large dependencies**
+    This is the most common cause of the problem. Some node modules are very large, mostly those that include native modules. Examples include `electron` and `chromium`. The function bundler is usually able to find out which modules are actually used by your code, but sometimes it will incorrectly include unneeded modules. If this is the case, you can either remove the module from your dependencies if you installed it yourself, or exclude it manually by adding something like this to your `netlify.toml`, changing the value according to the problematic module:
+
+    ```toml
+    [functions]
+    excluded_files = "node_modules/electron/**/*"
+    ```
+    If you do need large modules (e.g. if you are running Puppeteer in a Next API route), consider changing to a Netlify function.
+
+- **Large numbers of pre-rendered pages**
+If you have a very large number of pre-rendered pages, these can take up a lot of space in the function. There are two approaches to fixing this. One is to consider deferring the building of the pages. If you set `fallback = "blocking"`, the rendering will be deferred until the first user requests the page. This is a good choice for low-traffic pages. It reduces build and deploy time, and can make your bundle a lot smaller. The other option is to enable an experimental feature that moves static files out of the function bundle. To do this, set the environment variable `EXPERIMENTAL_MOVE_STATIC_PAGES` to true.


### PR DESCRIPTION
Add info to the readme about monorepo setup, and a page about diagnosing large function sizes. Adds a link in the console warning about large functions