### PR TITLE
fix: ensure stale-while-revalidate headers are not sent

### DIFF
--- a/src/templates/getHandler.js
+++ b/src/templates/getHandler.js
@@ -136,6 +136,11 @@ const makeHandler =
         multiValueHeaders['cache-control'] = ['no-cache']
       }
 
+      // Sending SWR headers causes undefined behaviour with the Netlify CDN
+      if (multiValueHeaders['cache-control']?.[0]?.includes('stale-while-revalidate')) {
+        multiValueHeaders['cache-control'] = ['public, max-age=0, must-revalidate']
+      }
+
       return {
         ...result,
         multiValueHeaders,


### PR DESCRIPTION
We do not support stale-while-revalidate cache headers, so this PR ensures that if they are set they are changed to `must-revalidate`

Test by loading [this page](https://deploy-preview-737--netlify-plugin-nextjs-demo.netlify.app/getStaticProps/withRevalidate/1) and observing cache-control header. For comparison [see the main branch](https://netlify-plugin-nextjs-demo.netlify.app/getStaticProps/withRevalidate/1).
