### PR TITLE
fix: disable serverless targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ publish = ".next"
 package = "@netlify/plugin-nextjs"
 ```
 
-If you previously set `target: "serverless"` or a custom `distDir` in your `next.config.js`, or set `node_bundler` or `external_node_modules` in your `netlify.toml` these are no longer needed and can be removed.
+If you previously set `target: "serverless"` or a custom `distDir` in your `next.config.js`, or set `node_bundler` or `external_node_modules` in your `netlify.toml` these are no longer needed and can be removed. 
+
+The `serverless` and `experimental-serverless-trace` targets are deprecated in Next 12, and all builds with this plugin will now use the default `server` target.
 
 If you are using a monorepo you will need to change `publish` to point to the full path to the built `.next` directory, which may be in a subdirectory. If you have changed your `distDir` then it will need to match that. 
 

--- a/src/helpers/verification.js
+++ b/src/helpers/verification.js
@@ -8,14 +8,6 @@ const outdent = require('outdent')
 const prettyBytes = require('pretty-bytes')
 const { satisfies } = require('semver')
 
-exports.verifyBuildTarget = (target) => {
-  if (target !== 'server') {
-    console.log(
-      yellowBright`Setting target to ${target} is no longer required. You should check if target=server works for you.`,
-    )
-  }
-}
-
 // This is when nft support was added
 const REQUIRED_BUILD_VERSION = '>=18.16.0'
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ const { generateFunctions, setupImageFunction, generatePagesResolver } = require
 const {
   verifyNetlifyBuildVersion,
   checkNextSiteHasBuilt,
-  verifyBuildTarget,
   checkForRootPublish,
   logBetaMessage,
   checkZipSize,
@@ -33,6 +32,10 @@ module.exports = {
     verifyNetlifyBuildVersion({ failBuild, ...constants })
 
     await restoreCache({ cache, publish })
+
+    netlifyConfig.build.environment ||= {}
+    // eslint-disable-next-line unicorn/consistent-destructuring
+    netlifyConfig.build.environment.NEXT_PRIVATE_TARGET = 'server'
   },
 
   async onBuild({
@@ -47,8 +50,6 @@ module.exports = {
     checkNextSiteHasBuilt({ publish, failBuild })
 
     const { appDir, basePath, i18n, images, target, ignore } = await getNextConfig({ publish, failBuild })
-
-    verifyBuildTarget(target)
 
     configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), publish) })
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,8 @@ beforeEach(async () => {
   cleanup = tmpDir.cleanup
 
   netlifyConfig.build.publish = path.posix.resolve('.next')
+  netlifyConfig.build.environment = {}
+
   netlifyConfig.redirects = []
   netlifyConfig.functions[HANDLER_FUNCTION_NAME] && (netlifyConfig.functions[HANDLER_FUNCTION_NAME].included_files = [])
   netlifyConfig.functions[ODB_FUNCTION_NAME] && (netlifyConfig.functions[ODB_FUNCTION_NAME].included_files = [])
@@ -88,7 +90,6 @@ beforeEach(async () => {
 afterEach(async () => {
   jest.clearAllMocks()
   jest.resetAllMocks()
-  delete process.env.NEXT_PRIVATE_TARGET
   // Cleans up the temporary directory from `getTmpDir()` and do not make it
   // the current directory anymore
   restoreCwd()
@@ -132,6 +133,13 @@ describe('preBuild()', () => {
     })
 
     expect(restore).toHaveBeenCalledWith(path.posix.resolve('.next/cache'))
+  })
+
+  it('forces the target to "server"', async () => {
+    const netlifyConfig = { ...defaultArgs.netlifyConfig }
+
+    await plugin.onPreBuild({ ...defaultArgs, netlifyConfig })
+    expect(netlifyConfig.build.environment.NEXT_PRIVATE_TARGET).toBe('server')
   })
 })
 


### PR DESCRIPTION
Setting the target is deprecated in Next 12, and prints a scary warning. As the plugin no longer requires the target to be set, this PR now changes the plugin to force the target to `server`.

Fixes #738 
