### PR TITLE
chore: edge functions can have a display name

### DIFF
--- a/packages/runtime/src/helpers/edge.ts
+++ b/packages/runtime/src/helpers/edge.ts
@@ -43,10 +43,12 @@ export interface FunctionManifest {
   functions: Array<
     | {
         function: string
+        name?: string
         path: string
       }
     | {
         function: string
+        name?: string
         pattern: string
       }
   >


### PR DESCRIPTION
### Summary

Edge functions can now have a display name.
