### PR TITLE
chore: rename npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 # Next.js Runtime
 
 <p align="center">
-  <a aria-label="npm version" href="https://www.npmjs.com/package/@netlify/plugin-nextjs">
-    <img alt="" src="https://img.shields.io/npm/v/@netlify/plugin-nextjs">
+  <a aria-label="npm version" href="https://www.npmjs.com/package/@opennextjs/netlify">
+    <img alt="" src="https://img.shields.io/npm/v/@opennextjs/netlify">
   </a>
-  <a aria-label="MIT License" href="https://img.shields.io/npm/l/@netlify/plugin-nextjs">
-    <img alt="" src="https://img.shields.io/npm/l/@netlify/plugin-nextjs">
+  <a aria-label="MIT License" href="https://img.shields.io/npm/l/@opennextjs/netlify">
+    <img alt="" src="https://img.shields.io/npm/l/@opennextjs/netlify">
   </a>
 </p>
 
@@ -37,21 +37,21 @@ manually in the following ways:
 
 ### From the UI (Recommended)
 
-You can go to the [UI](https://app.netlify.com/plugins/@netlify/plugin-nextjs/install) and choose
-the site to install the Next.js Runtime on. This method is recommended because you will benefit from
+You can go to the [UI](https://app.netlify.com/plugins/@opennextjs/netlify/install) and choose the
+site to install the Next.js Runtime on. This method is recommended because you will benefit from
 auto-upgrades to important fixes and feature updates.
 
 ### From `npm`
 
 ```shell
-npm install -D @netlify/plugin-nextjs
+npm install -D @opennextjs/netlify
 ```
 
 ...then add the following to your `netlify.toml` file:
 
 ```toml
 [[plugins]]
-  package = "@netlify/plugin-nextjs"
+  package = "@opennextjs/netlify"
 ```
 
 This method is recommended if you wish to pin the Next.js Runtime to a specific version.

--- a/e2e-report/netlify.toml
+++ b/e2e-report/netlify.toml
@@ -2,6 +2,3 @@
 base = "e2e-report/"
 command = "next build"
 publish = ".next"
-
-[[plugins]]
-package = "@netlify/plugin-nextjs"

--- a/e2e-report/package-lock.json
+++ b/e2e-report/package-lock.json
@@ -8,7 +8,6 @@
       "name": "e2e-test-site",
       "version": "0.2.0",
       "dependencies": {
-        "@netlify/plugin-nextjs": "^5.8.1",
         "next": "^14.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -260,15 +259,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@netlify/plugin-nextjs": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.8.1.tgz",
-      "integrity": "sha512-WB1N0FslhWZ1yAVYTcB6CcFrFOUSQ0O2LfavYZrbAypeNxu2I+oO+cgmhfDgZ8Eoq1g4EMeoIGMkNoZ4ogZTsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/e2e-report/package.json
+++ b/e2e-report/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@netlify/plugin-nextjs": "^5.8.1",
     "next": "^14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,1 +1,1 @@
-name: '@netlify/plugin-nextjs'
+name: '@opennextjs/netlify'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@netlify/plugin-nextjs",
+  "name": "@opennextjs/netlify",
   "version": "5.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@netlify/plugin-nextjs",
+      "name": "@opennextjs/netlify",
       "version": "5.8.1",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@netlify/plugin-nextjs",
+  "name": "@opennextjs/netlify",
   "version": "5.8.1",
   "description": "Run Next.js seamlessly on Netlify",
   "main": "./dist/index.js",

--- a/src/build/verification.ts
+++ b/src/build/verification.ts
@@ -57,7 +57,7 @@ export function verifyPublishDir(ctx: PluginContext) {
       !satisfies(ctx.nextVersion, SUPPORTED_NEXT_VERSIONS, { includePrerelease: true })
     ) {
       ctx.failBuild(
-        `@netlify/plugin-nextjs@5 requires Next.js version ${SUPPORTED_NEXT_VERSIONS}, but found ${ctx.nextVersion}. Please upgrade your project's Next.js version.`,
+        `@opennextjs/netlify@5 requires Next.js version ${SUPPORTED_NEXT_VERSIONS}, but found ${ctx.nextVersion}. Please upgrade your project's Next.js version.`,
       )
     }
   }
@@ -85,7 +85,7 @@ export async function verifyAdvancedAPIRoutes(ctx: PluginContext) {
 
   if (unsupportedAPIRoutes.length !== 0) {
     ctx.failBuild(
-      `@netlify/plugin-nextjs@5 does not support advanced API routes. The following API routes should be migrated to Netlify background or scheduled functions:\n${unsupportedAPIRoutes.map((apiRouteConfig) => ` - ${apiRouteConfig.apiRoute} (type: "${apiRouteConfig.config.type}")`).join('\n')}\n\nRefer to https://ntl.fyi/next-scheduled-bg-function-migration as migration example.`,
+      `@opennextjs/netlify@5 does not support advanced API routes. The following API routes should be migrated to Netlify background or scheduled functions:\n${unsupportedAPIRoutes.map((apiRouteConfig) => ` - ${apiRouteConfig.apiRoute} (type: "${apiRouteConfig.config.type}")`).join('\n')}\n\nRefer to https://ntl.fyi/next-scheduled-bg-function-migration as migration example.`,
     )
   }
 }
@@ -119,7 +119,7 @@ export function verifyNetlifyForms(ctx: PluginContext, html: string) {
     formDetectionRegex.test(html)
   ) {
     ctx.failBuild(
-      '@netlify/plugin-nextjs@5 requires migration steps to support Netlify Forms. Refer to https://ntl.fyi/next-runtime-forms-migration for migration example.',
+      '@opennextjs/netlify@5 requires migration steps to support Netlify Forms. Refer to https://ntl.fyi/next-runtime-forms-migration for migration example.',
     )
   }
 }

--- a/tests/integration/advanced-api-routes.test.ts
+++ b/tests/integration/advanced-api-routes.test.ts
@@ -26,7 +26,7 @@ it<FixtureTestContext>('test', async (ctx) => {
   const runPluginPromise = runPlugin(ctx)
 
   await expect(runPluginPromise).rejects.toThrow(
-    '@netlify/plugin-nextjs@5 does not support advanced API routes. The following API routes should be migrated to Netlify background or scheduled functions:',
+    '@opennextjs/netlify@5 does not support advanced API routes. The following API routes should be migrated to Netlify background or scheduled functions:',
   )
 
   // list API routes to migrate

--- a/tests/integration/netlify-forms.test.ts
+++ b/tests/integration/netlify-forms.test.ts
@@ -25,7 +25,7 @@ it<FixtureTestContext>('should fail build when netlify forms are used', async (c
   const runPluginPromise = runPlugin(ctx)
 
   await expect(runPluginPromise).rejects.toThrow(
-    '@netlify/plugin-nextjs@5 requires migration steps to support Netlify Forms. Refer to https://ntl.fyi/next-runtime-forms-migration for migration example.',
+    '@opennextjs/netlify@5 requires migration steps to support Netlify Forms. Refer to https://ntl.fyi/next-runtime-forms-migration for migration example.',
   )
 })
 

--- a/tests/smoke/deploy.test.ts
+++ b/tests/smoke/deploy.test.ts
@@ -66,7 +66,7 @@ describe('version check', () => {
     async () => {
       await expect(selfCleaningFixtureFactories.next12_1_0()).rejects.toThrow(
         new RegExp(
-          `@netlify/plugin-nextjs@5 requires Next.js version >=13.5.0, but found 12.1.0. Please upgrade your project's Next.js version.`,
+          `@opennextjs/netlify@5 requires Next.js version >=13.5.0, but found 12.1.0. Please upgrade your project's Next.js version.`,
         ),
       )
     },
@@ -83,7 +83,7 @@ describe('version check', () => {
         selfCleaningFixtureFactories.yarnMonorepoMultipleNextVersionsSiteIncompatible(),
       ).rejects.toThrow(
         new RegExp(
-          `@netlify/plugin-nextjs@5 requires Next.js version >=13.5.0, but found 13.4.1. Please upgrade your project's Next.js version.`,
+          `@opennextjs/netlify@5 requires Next.js version >=13.5.0, but found 13.4.1. Please upgrade your project's Next.js version.`,
         ),
       )
     },
@@ -101,7 +101,7 @@ describe('version check', () => {
         fixtureFactories.npmNestedSiteMultipleNextVersionsIncompatible(),
       ).rejects.toThrow(
         new RegExp(
-          `@netlify/plugin-nextjs@5 requires Next.js version >=13.5.0, but found 13.4.1. Please upgrade your project's Next.js version.`,
+          `@opennextjs/netlify@5 requires Next.js version >=13.5.0, but found 13.4.1. Please upgrade your project's Next.js version.`,
         ),
       )
     },

--- a/tests/smoke/fixtures/npm-monorepo-empty-base/apps/site/netlify.toml
+++ b/tests/smoke/fixtures/npm-monorepo-empty-base/apps/site/netlify.toml
@@ -2,6 +2,3 @@
 base = ""
 command = "npm run build"
 publish = "apps/site/.next"
-
-[[plugins]]
-package = "@netlify/plugin-nextjs"

--- a/tests/smoke/fixtures/npm-monorepo-site-created-at-build/netlify.toml
+++ b/tests/smoke/fixtures/npm-monorepo-site-created-at-build/netlify.toml
@@ -1,6 +1,3 @@
 [build]
 command = "node setup-site.mjs && npm install && npm run build -w apps/site"
 publish = "./apps/site/.next"
-
-[[plugins]]
-package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Description

repo: netlify/next-runtime → opennextjs/opennextjs-netlify in https://github.com/opennextjs/opennextjs-netlify/pull/2696

npm package: @netlify/plugin-nextjs → @opennextjs/netlify in this PR

CI will fail until we bump netlify-cli https://github.com/netlify/cli/pull/6896

### Documentation

This PR updates the README and CONTRIBUTING files. The public docs will be updated in https://github.com/netlify/docs/pull/4196.

## Tests

TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

FRB-1400