### PR TITLE
ci: fix lint workflow for forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
It looks like the lint workflow doesn't work for PRs from PRs. See this run for example (scroll to Checkout > Determining the checkout info): https://github.com/opennextjs/opennextjs-netlify/actions/runs/11981106242/job/33483732033?pr=2707.

All the other uses of `actions/checkout` omit this `with.ref` option so I'm assuming that's the culprit here. It must be trying to reference the ref in this repo.