### PR TITLE
test: update assertion to allow image cdn responses be webp

### DIFF
--- a/tests/e2e/export.test.ts
+++ b/tests/e2e/export.test.ts
@@ -64,8 +64,10 @@ test.describe('next/image is using Netlify Image CDN', () => {
 
     expect(nextImageResponse.status()).toBe(200)
     // ensure next/image is using Image CDN
-    // source image is jpg, but when requesting it through Image CDN avif will be returned
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    // source image is jpg, but when requesting it through Image CDN avif or webp will be returned
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -119,8 +119,10 @@ test.describe('next/image is using Netlify Image CDN', () => {
 
     expect(nextImageResponse.status()).toBe(200)
     // ensure next/image is using Image CDN
-    // source image is jpg, but when requesting it through Image CDN avif will be returned
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    // source image is jpg, but when requesting it through Image CDN avif or webp will be returned
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })
@@ -142,7 +144,9 @@ test.describe('next/image is using Netlify Image CDN', () => {
     )
 
     expect(nextImageResponse.status()).toBe(200)
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })
@@ -164,7 +168,9 @@ test.describe('next/image is using Netlify Image CDN', () => {
     )
 
     expect(nextImageResponse.status()).toBe(200)
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })
@@ -183,7 +189,9 @@ test.describe('next/image is using Netlify Image CDN', () => {
     )
 
     expect(nextImageResponse?.status()).toBe(200)
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })
@@ -203,7 +211,9 @@ test.describe('next/image is using Netlify Image CDN', () => {
     )
 
     expect(nextImageResponse.status()).toEqual(200)
-    expect(await nextImageResponse.headerValue('content-type')).toEqual('image/avif')
+    expect(['image/avif', 'image/webp']).toContain(
+      await nextImageResponse.headerValue('content-type'),
+    )
 
     await expectImageWasLoaded(page.locator('img'))
   })


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Preferred format was moved to webp from avif, so this loosens up our assertion to accept either - as long as it's not the same as source image this should ensure there is some processing happening on the image