### PR TITLE
fix: keep __nextDataReq query param working

### DIFF
--- a/src/run/handlers/server.ts
+++ b/src/run/handlers/server.ts
@@ -83,6 +83,15 @@ export default async (request: Request) => {
       },
     })
 
+    if (new URL(request.url).searchParams.get('__nextDataReq')) {
+      const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
+      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
+      const meta = req[NEXT_REQUEST_META] ?? {}
+      meta.isNextDataReq = true
+      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
+      req[NEXT_REQUEST_META] = meta
+    }
+
     disableFaultyTransferEncodingHandling(res as unknown as ComputeJsOutgoingMessage)
 
     const requestContext = getRequestContext() ?? createRequestContext()

--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -52,3 +52,23 @@ test('it should render OpenGraph image meta tag correctly', async ({ page, middl
   const size = await getImageSize(Buffer.from(imageBuffer), 'png')
   expect([size.width, size.height]).toEqual([1200, 630])
 })
+
+test('json data rewrite works', async ({ middlewarePages }) => {
+  const response = await fetch(
+    `${middlewarePages.url}/_next/data/build-id/sha.json?__nextDataReq=1`,
+    {
+      headers: {
+        'x-nextjs-data': '1',
+      },
+    },
+  )
+
+  expect(response.ok).toBe(true)
+  const body = await response.text()
+
+  expect(body).toMatch(/^{"pageProps":/)
+
+  const data = JSON.parse(body)
+
+  expect(data.pageProps.message).toBeDefined()
+})

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -325,6 +325,7 @@ export const fixtureFactories = {
   bun: () => createE2EFixture('simple', { packageManger: 'bun' }),
   middleware: () => createE2EFixture('middleware'),
   middlewareOg: () => createE2EFixture('middleware-og'),
+  middlewarePages: () => createE2EFixture('middleware-pages'),
   pageRouter: () => createE2EFixture('page-router'),
   pageRouterBasePathI18n: () => createE2EFixture('page-router-base-path-i18n'),
   turborepo: () =>


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

This is attempting to address changes made in https://github.com/vercel/next.js/pull/74100 by keeping previous query param "working".

This feels like wrong approach to me, but I'm not quite sure how this should be fixed properly. In our middleware handling we are relying on this search param: https://github.com/opennextjs/opennextjs-netlify/blob/c3e328c67aee611f83567ebf95c86abcfdd52d93/edge-runtime/lib/response.ts#L182-L186 

Maybe instead we should transform pathname into json data path instead of keeping it as cannonical route path with added query param, but comment in existing code gives me a pause - I'm not sure if it's about our own handling or it's about Next handling in general. 

This feels like quickest (and quite hacky ...) way to keep middleware rewrites for data routes working, so maybe this could be considered stop-gap solution that will do for now, until more investigation can happen.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added e2e test (we only had integration tests really and those were not checking all parts of handling request - one test was checking origin - literally if using `__nextDataReq` search param results in data response and the other one was testing just middleware part)

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1545/investigate-integration-test-failures-due-to-recent-pr-changes
