### PR TITLE
fix: adjust middleware json data rewrite to work with recent next@canary

### DIFF
--- a/src/run/handlers/server.ts
+++ b/src/run/handlers/server.ts
@@ -83,6 +83,15 @@ export default async (request: Request) => {
       },
     })
 
+    if (new URL(request.url).searchParams.get('__nextDataReq')) {
+      const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
+      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
+      const meta = req[NEXT_REQUEST_META] ?? {}
+      meta.isNextDataReq = true
+      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
+      req[NEXT_REQUEST_META] = meta
+    }
+
     disableFaultyTransferEncodingHandling(res as unknown as ComputeJsOutgoingMessage)
 
     const requestContext = getRequestContext() ?? createRequestContext()

--- a/src/run/handlers/server.ts
+++ b/src/run/handlers/server.ts
@@ -83,15 +83,6 @@ export default async (request: Request) => {
       },
     })
 
-    if (new URL(request.url).searchParams.get('__nextDataReq')) {
-      const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
-      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
-      const meta = req[NEXT_REQUEST_META] ?? {}
-      meta.isNextDataReq = true
-      // @ts-expect-error NEXT_REQUEST_META doesn't exist in IncomingMessage type
-      req[NEXT_REQUEST_META] = meta
-    }
-
     disableFaultyTransferEncodingHandling(res as unknown as ComputeJsOutgoingMessage)
 
     const requestContext = getRequestContext() ?? createRequestContext()

--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -54,14 +54,11 @@ test('it should render OpenGraph image meta tag correctly', async ({ page, middl
 })
 
 test('json data rewrite works', async ({ middlewarePages }) => {
-  const response = await fetch(
-    `${middlewarePages.url}/_next/data/build-id/sha.json?__nextDataReq=1`,
-    {
-      headers: {
-        'x-nextjs-data': '1',
-      },
+  const response = await fetch(`${middlewarePages.url}/_next/data/build-id/sha.json`, {
+    headers: {
+      'x-nextjs-data': '1',
     },
-  )
+  })
 
   expect(response.ok).toBe(true)
   const body = await response.text()

--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -52,3 +52,23 @@ test('it should render OpenGraph image meta tag correctly', async ({ page, middl
   const size = await getImageSize(Buffer.from(imageBuffer), 'png')
   expect([size.width, size.height]).toEqual([1200, 630])
 })
+
+test('json data rewrite works', async ({ middlewarePages }) => {
+  const response = await fetch(
+    `${middlewarePages.url}/_next/data/build-id/sha.json?__nextDataReq=1`,
+    {
+      headers: {
+        'x-nextjs-data': '1',
+      },
+    },
+  )
+
+  expect(response.ok).toBe(true)
+  const body = await response.text()
+
+  expect(body).toMatch(/^{"pageProps":/)
+
+  const data = JSON.parse(body)
+
+  expect(data.pageProps.message).toBeDefined()
+})

--- a/tests/fixtures/middleware-pages/next-env.d.ts
+++ b/tests/fixtures/middleware-pages/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/tests/fixtures/middleware-pages/next.config.js
+++ b/tests/fixtures/middleware-pages/next.config.js
@@ -21,6 +21,7 @@ if (platform === 'win32') {
   }
 }
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   trailingSlash: true,
   output: 'standalone',

--- a/tests/fixtures/middleware-pages/package.json
+++ b/tests/fixtures/middleware-pages/package.json
@@ -13,6 +13,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.47"
+    "@types/node": "^20.10.6",
+    "@types/react": "18.2.47",
+    "typescript": "^5.3.3"
   }
 }

--- a/tests/fixtures/middleware-pages/tsconfig.json
+++ b/tests/fixtures/middleware-pages/tsconfig.json
@@ -11,7 +11,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "target": "ES2017"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/tests/integration/edge-handler.test.ts
+++ b/tests/integration/edge-handler.test.ts
@@ -387,8 +387,7 @@ describe('page router', () => {
     })
     const res = await response.json()
     const url = new URL(res.url, 'http://n/')
-    expect(url.pathname).toBe('/ssr-page-2/')
-    expect(url.searchParams.get('__nextDataReq')).toBe('1')
+    expect(url.pathname).toBe('/_next/data/build-id/ssr-page-2.json')
     expect(res.headers['x-nextjs-data']).toBe('1')
     expect(response.headers.get('x-nextjs-rewrite')).toBe('/ssr-page-2/')
     expect(response.status).toBe(200)
@@ -420,7 +419,7 @@ describe('page router', () => {
     expect(response.status).toBe(200)
   })
 
-  test<FixtureTestContext>('should rewrite un-rewritten data requests to page route', async (ctx) => {
+  test<FixtureTestContext>('should NOT rewrite un-rewritten data requests to page route', async (ctx) => {
     await createFixture('middleware-pages', ctx)
     await runPlugin(ctx)
     const origin = await LocalServer.run(async (req, res) => {
@@ -443,8 +442,7 @@ describe('page router', () => {
     })
     const res = await response.json()
     const url = new URL(res.url, 'http://n/')
-    expect(url.pathname).toBe('/ssg/hello/')
-    expect(url.searchParams.get('__nextDataReq')).toBe('1')
+    expect(url.pathname).toBe('/_next/data/build-id/ssg/hello.json')
     expect(res.headers['x-nextjs-data']).toBe('1')
     expect(response.status).toBe(200)
   })
@@ -472,8 +470,7 @@ describe('page router', () => {
     })
     const res = await response.json()
     const url = new URL(res.url, 'http://n/')
-    expect(url.pathname).toBe('/blog/first/')
-    expect(url.searchParams.get('__nextDataReq')).toBe('1')
+    expect(url.pathname).toBe('/_next/data/build-id/blog/first.json')
     expect(url.searchParams.get('slug')).toBe('first')
     expect(res.headers['x-nextjs-data']).toBe('1')
     expect(response.status).toBe(200)

--- a/tests/integration/page-router.test.ts
+++ b/tests/integration/page-router.test.ts
@@ -95,22 +95,6 @@ test<FixtureTestContext>('Should revalidate path with On-demand Revalidation', a
   expect(dateCacheInitial).not.toBe(dateCacheRevalidated)
 })
 
-test<FixtureTestContext>('Should return JSON for data req to page route', async (ctx) => {
-  await createFixture('page-router', ctx)
-  await runPlugin(ctx)
-
-  const response = await invokeFunction(ctx, {
-    url: '/static/revalidate-manual?__nextDataReq=1',
-    headers: { 'x-nextjs-data': '1' },
-  })
-
-  expect(response.body).toMatch(/^{"pageProps":/)
-
-  const data = JSON.parse(response.body)
-
-  expect(data.pageProps.show).toBeDefined()
-})
-
 test.skipIf(platform === 'win32')<FixtureTestContext>(
   'Should set permanent "netlify-cdn-cache-control" header on fully static pages"',
   async (ctx) => {

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -325,6 +325,7 @@ export const fixtureFactories = {
   bun: () => createE2EFixture('simple', { packageManger: 'bun' }),
   middleware: () => createE2EFixture('middleware'),
   middlewareOg: () => createE2EFixture('middleware-og'),
+  middlewarePages: () => createE2EFixture('middleware-pages'),
   pageRouter: () => createE2EFixture('page-router'),
   pageRouterBasePathI18n: () => createE2EFixture('page-router-base-path-i18n'),
   turborepo: () =>


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Adjusts middleware handling to use json data urls and not route paths with `__nextDataReq` query param (that no longer works with recent next@canary after https://github.com/vercel/next.js/pull/74100) for middleware json data rewrites

--- 

Initial previous attempt description below (this felt the quickest "hot fix" but it seemed really wrong to do so):

~This is attempting to address changes made in https://github.com/vercel/next.js/pull/74100 by keeping previous query param "working".~

~This feels like wrong approach to me, but I'm not quite sure how this should be fixed properly. In our middleware handling we are relying on this search param:~ https://github.com/opennextjs/opennextjs-netlify/blob/c3e328c67aee611f83567ebf95c86abcfdd52d93/edge-runtime/lib/response.ts#L182-L186 

~Maybe instead we should transform pathname into json data path instead of keeping it as cannonical route path with added query param, but comment in existing code gives me a pause - I'm not sure if it's about our own handling or it's about Next handling in general.~

~This feels like quickest (and quite hacky ...) way to keep middleware rewrites for data routes working, so maybe this could be considered stop-gap solution that will do for now, until more investigation can happen.~

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added e2e test (we only had integration tests really and those were not checking all parts of handling request - one test was checking origin - literally if using `__nextDataReq` search param results in data response (I did remove this one as it would no longer work with `next@canary` and because we are not relying on this behavior anymore) and the other ones were testing just middleware part - I did update those)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1545/investigate-integration-test-failures-due-to-recent-pr-changes
