### PR TITLE
fix: use uint8array for htmlrewriter wasm module instead of base64

### DIFF
--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -97,14 +97,13 @@ const writeHandlerFile = async (ctx: PluginContext, { matchers, name }: NextDefi
   await writeFile(
     join(handlerDirectory, `${handlerName}.js`),
     `
-    import { decode as _base64Decode } from './edge-runtime/vendor/deno.land/std@0.175.0/encoding/base64.ts';
     import { init as htmlRewriterInit } from './edge-runtime/vendor/deno.land/x/htmlrewriter@v1.0.0/src/index.ts'
-    import {handleMiddleware} from './edge-runtime/middleware.ts';
+    import { handleMiddleware } from './edge-runtime/middleware.ts';
     import handler from './server/${name}.js';
 
-    await htmlRewriterInit({ module_or_path: _base64Decode(${JSON.stringify(
-      htmlRewriterWasm.toString('base64'),
-    )}).buffer });
+    await htmlRewriterInit({ module_or_path: Uint8Array.from(${JSON.stringify([
+      ...htmlRewriterWasm,
+    ])}) });
 
     export default (req, context) => handleMiddleware(req, context, handler);
     `,


### PR DESCRIPTION
This reduces the amount of memory being used by the function, base64 will use four thirds of the original size, whereas using uint8array will use the same size as the original size