### PR TITLE
fix: use uint8array for user's wasm modules used in middleware instead of base64

### DIFF
--- a/edge-runtime/vendor.ts
+++ b/edge-runtime/vendor.ts
@@ -2,7 +2,6 @@
 // It acts as a seed that populates the `vendor/` directory and should not be
 // imported directly.
 
-import 'https://deno.land/std@0.175.0/encoding/base64.ts'
 import 'https://deno.land/std@0.175.0/http/cookie.ts'
 import 'https://deno.land/std@0.175.0/node/buffer.ts'
 import 'https://deno.land/std@0.175.0/node/events.ts'


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Similar as https://github.com/opennextjs/opennextjs-netlify/pull/2739 but this time for wasm modules used by user in middleware (and not wasm module we built into middleware).

Also allows us to drop direct `https://deno.land/std@0.175.0/encoding/base64.ts` dependency (we still have as indirect one tho :) )

## Tests

We already have test that would caught regression - https://github.com/opennextjs/opennextjs-netlify/blob/25f6f300f481483ab445cf6fb2b9d181d50d2637/tests/integration/wasm.test.ts#L61-L77


