### PR TITLE
chore: add location header to trailing slash log

### DIFF
--- a/src/run/headers.ts
+++ b/src/run/headers.ts
@@ -238,7 +238,7 @@ export const setCacheControlHeaders = (
   // temporary diagnostic to evaluate number of trailing slash redirects
   if (status === 308 && request.url.endsWith('/') !== nextConfig.trailingSlash) {
     getLogger()
-      .withFields({ trailingSlash: nextConfig.trailingSlash })
+      .withFields({ trailingSlash: nextConfig.trailingSlash, location: headers.get('location') })
       .log('NetlifyHeadersHandler.trailingSlashRedirect')
   }
 


### PR DESCRIPTION
## Description

Update to #2743 to better understand whether we are capturing the right condition to match trailing slash redirects.