### PR TITLE
ci: run deploy command from e2e-report dir

### DIFF
--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -57,4 +57,5 @@ jobs:
       - name: Deploy e2e page
         if: success()
         run: |
-          npx netlify deploy --build --cwd e2e-report
+          npx netlify deploy --build --cwd .
+        working-directory: e2e-report


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

default github actions image was updated to ubuntu24 which removed globally provided netlify-cli, so attempting to `npx netlify` from root of repo in this workflow won't work, because we only install dependencies inside `e2e-report` dir - so this moves working dir from root to `e2e-report` to be able to use locally installed cli

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
