### PR TITLE
ci: increase number of shards when running Next.js repo e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -63,7 +63,7 @@ jobs:
             echo "group=[1, 2, 3, 4, 5, 6]" >> $GITHUB_OUTPUT
             echo "total=6" >> $GITHUB_OUTPUT
           else
-            VERSION_SELECTORS=[\"latest\"]
+            VERSION_SELECTORS=[\"latest\",\"canary\"]
             echo "group=[1, 2, 3, 4, 5, 6]" >> $GITHUB_OUTPUT
             echo "total=6" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,16 +56,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION_SELECTORS=[${{ github.event.inputs.versions }}]
-            echo "group=[1, 2, 3, 4]" >> $GITHUB_OUTPUT
-            echo "total=4" >> $GITHUB_OUTPUT
+            echo "group=[1, 2, 3, 4, 5, 6]" >> $GITHUB_OUTPUT
+            echo "total=6" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             VERSION_SELECTORS=[\"latest\"]
-            echo "group=[1, 2, 3, 4]" >> $GITHUB_OUTPUT
-            echo "total=4" >> $GITHUB_OUTPUT
+            echo "group=[1, 2, 3, 4, 5, 6]" >> $GITHUB_OUTPUT
+            echo "total=6" >> $GITHUB_OUTPUT
           else
-            VERSION_SELECTORS=[\"latest\",\"canary\",\"14.2.15\",\"13.5.1\"]
-            echo "group=[1, 2, 3, 4]" >> $GITHUB_OUTPUT
-            echo "total=4" >> $GITHUB_OUTPUT
+            VERSION_SELECTORS=[\"latest\"]
+            echo "group=[1, 2, 3, 4, 5, 6]" >> $GITHUB_OUTPUT
+            echo "total=6" >> $GITHUB_OUTPUT
           fi
 
           VERSION_SPEC="["

--- a/tests/netlify-deploy.ts
+++ b/tests/netlify-deploy.ts
@@ -90,6 +90,10 @@ export class NextDeployInstance extends NextInstance {
           command = "npm run build"
           publish = ".next"
 
+          [build.environment]
+          # this allows to use "CanaryOnly" features with next@latest
+          NEXT_PRIVATE_TEST_MODE = "e2e"
+
           [[plugins]]
           package = "${runtimePackageName}"
           `


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

We are currently hitting 120 minutes timeout when running Next.js repo e2e tests ( https://github.com/opennextjs/opennextjs-netlify/actions/runs/12981472164/job/36199955881 as an example) and because of that we don't have successful test run we can use to produce more up-to-date report.

This does increase number of shards we use, and also at least temporarily disable non-latest version runs (to somewhat limit impact of github action concurrency limit we currently have)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1604/fix-vercelnextjs-e2e-report
