### PR TITLE
fix(perf): exclude entire `/_next/static/` dir from generated function

### DIFF
--- a/src/build/templates/handler-monorepo.tmpl.js
+++ b/src/build/templates/handler-monorepo.tmpl.js
@@ -53,4 +53,9 @@ export default async function (req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
+  excludedPath: [
+    // We use `preferStatic: true` so we already won't run this on *existing* static assets,
+    // but by excluding this entire path we also avoid invoking the function just to 404.
+    '/_next/static/*',
+  ],
 }

--- a/src/build/templates/handler.tmpl.js
+++ b/src/build/templates/handler.tmpl.js
@@ -46,4 +46,9 @@ export default async function handler(req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
+  excludedPath: [
+    // We use `preferStatic: true` so we already won't run this on *existing* static assets,
+    // but by excluding this entire path we also avoid invoking the function just to 404.
+    '/_next/static/*',
+  ],
 }

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -21,6 +21,7 @@ export interface DeployResult {
   deployID: string
   url: string
   logs: string
+  isolatedFixtureRoot: string
 }
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'berry'
@@ -92,6 +93,7 @@ export const createE2EFixture = async (fixture: string, config: E2EConfig = {}) 
       cleanup: _cleanup,
       deployID: result.deployID,
       url: result.url,
+      isolatedFixtureRoot,
     }
   } catch (error) {
     await _cleanup(true)


### PR DESCRIPTION
## Description

See inline comment. This only matters because of browsers requesting assets from previous deploys or bots crawling for garbage. This will avoid unnecessary function invocations in those cases, improving performance and reducing customer bills in some cases.

### Documentation

N/A

## Tests

Added e2e coverage (requires the full Netlify platform to be exercised)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

