### PR TITLE
fix: set immutable cache-control for _next/static

### DIFF
--- a/src/build/content/static.ts
+++ b/src/build/content/static.ts
@@ -77,6 +77,20 @@ export const copyStaticAssets = async (ctx: PluginContext): Promise<void> => {
   })
 }
 
+export const setHeadersConfig = async (ctx: PluginContext): Promise<void> => {
+  // https://nextjs.org/docs/app/api-reference/config/next-config-js/headers#cache-control
+  // Next.js sets the Cache-Control header of public, max-age=31536000, immutable for truly
+  // immutable assets. It cannot be overridden. These immutable files contain a SHA-hash in
+  // the file name, so they can be safely cached indefinitely.
+  const { basePath } = ctx.buildConfig
+  ctx.netlifyConfig.headers.push({
+    for: `${basePath}/_next/static/*`,
+    values: {
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  })
+}
+
 export const copyStaticExport = async (ctx: PluginContext): Promise<void> => {
   await tracer.withActiveSpan('copyStaticExport', async () => {
     if (!ctx.exportDetail?.outDirectory) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   copyStaticContent,
   copyStaticExport,
   publishStaticDir,
+  setHeadersConfig,
   unpublishStaticDir,
 } from './build/content/static.js'
 import { clearStaleEdgeHandlers, createEdgeHandlers } from './build/functions/edge.js'
@@ -66,7 +67,7 @@ export const onBuild = async (options: NetlifyPluginOptions) => {
 
     // static exports only need to be uploaded to the CDN and setup /_next/image handler
     if (ctx.buildConfig.output === 'export') {
-      return Promise.all([copyStaticExport(ctx), setImageConfig(ctx)])
+      return Promise.all([copyStaticExport(ctx), setHeadersConfig(ctx), setImageConfig(ctx)])
     }
 
     await verifyAdvancedAPIRoutes(ctx)
@@ -78,6 +79,7 @@ export const onBuild = async (options: NetlifyPluginOptions) => {
       copyPrerenderedContent(ctx),
       createServerHandler(ctx),
       createEdgeHandlers(ctx),
+      setHeadersConfig(ctx),
       setImageConfig(ctx),
     ])
   })

--- a/tests/utils/fixture.ts
+++ b/tests/utils/fixture.ts
@@ -207,6 +207,7 @@ export async function runPluginStep(
       // INTERNAL_EDGE_FUNCTIONS_SRC: '.netlify/edge-functions',
     },
     netlifyConfig: {
+      headers: [],
       redirects: [],
     },
     utils: {

--- a/tests/utils/playwright-helpers.ts
+++ b/tests/utils/playwright-helpers.ts
@@ -14,6 +14,7 @@ const makeE2EFixture = (
 
 export const test = base.extend<
   {
+    ensureStaticAssetsHaveImmutableCacheControl: void
     takeScreenshot: void
     pollUntilHeadersMatch: (
       url: string,
@@ -88,6 +89,21 @@ export const test = base.extend<
         })
         await page.screenshot({ path: screenshotPath, timeout: 5000 })
       }
+    },
+    { auto: true },
+  ],
+  ensureStaticAssetsHaveImmutableCacheControl: [
+    async ({ page }, use) => {
+      page.on('response', (response) => {
+        if (response.url().includes('/_next/static/')) {
+          expect(
+            response.headers()['cache-control'],
+            '_next/static assets should have immutable cache control',
+          ).toContain('public,max-age=31536000,immutable')
+        }
+      })
+
+      await use()
     },
     { auto: true },
   ],


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

We currently use default cache-control for `_next/static` which is `public,max-age=0,must-revalidate` while it should be `public,max-age=31536000,immutable` (per https://nextjs.org/docs/app/api-reference/config/next-config-js/headers#cache-control) as those assets have content hash in filename and therefore should be just permamently cached by browser without the need to revalidate with CDN

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added global automatic fixture that ~passively assert `_next/static` responses cache-control header

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1642/set-immutable-cache-control-headers-for-immutable-nextjs-assets
