### PR TITLE
fix: dynamic not-prerendered routes revalidate tracking

### DIFF
--- a/src/run/handlers/cache.cts
+++ b/src/run/handlers/cache.cts
@@ -197,7 +197,7 @@ export class NetlifyCacheHandler implements CacheHandlerForMultipleVersions {
           join(this.options.serverDistDir, '..', 'prerender-manifest.json'),
         ) as PrerenderManifest
 
-        if (typeof cacheControl !== undefined) {
+        if (typeof cacheControl !== 'undefined') {
           // instead of `revalidate` property, we might get `cacheControls` ( https://github.com/vercel/next.js/pull/76207 )
           // then we need to keep track of revalidate values via SharedCacheControls
           const { SharedCacheControls } = await import(

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -413,12 +413,12 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     expect(date1.localeCompare(beforeFirstFetch)).toBeGreaterThan(0)
 
     // allow page to get stale
-    await page.waitForTimeout(60_000)
+    await page.waitForTimeout(61_000)
 
     const response2 = await page.goto(new URL(pathname, pageRouter.url).href)
     expect(response2?.status()).toBe(200)
     expect(response2?.headers()['cache-status']).toMatch(
-      /"Netlify (Edge|Durable)"; hit; fwd=stale/m,
+      /("Netlify Edge"; hit; fwd=stale|"Netlify Durable"; hit; ttl=-[0-9]+)/m,
     )
     expect(response2?.headers()['netlify-cdn-cache-control']).toMatch(
       /s-maxage=60, stale-while-revalidate=[0-9]+, durable/,
@@ -436,8 +436,8 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     const response3 = await page.goto(new URL(pathname, pageRouter.url).href)
     expect(response3?.status()).toBe(200)
     expect(response3?.headers()['cache-status']).toMatch(
-      // hit, without being followed by ';fwd=stale'
-      /"Netlify (Edge|Durable)"; hit(?!; fwd=stale)/m,
+      // hit, without being followed by ';fwd=stale' for edge or negative TTL for durable, optionally with fwd=stale
+      /("Netlify Edge"; hit(?!; fwd=stale)|"Netlify Durable"; hit(?!; ttl=-[0-9]+))/m,
     )
     expect(response3?.headers()['netlify-cdn-cache-control']).toMatch(
       /s-maxage=60, stale-while-revalidate=[0-9]+, durable/,

--- a/tests/fixtures/wasm-src/src/app/og-node/route.js
+++ b/tests/fixtures/wasm-src/src/app/og-node/route.js
@@ -6,3 +6,5 @@ export async function GET() {
     height: 630,
   })
 }
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm-src/src/app/og/route.js
+++ b/tests/fixtures/wasm-src/src/app/og/route.js
@@ -8,3 +8,5 @@ export async function GET() {
 }
 
 export const runtime = 'edge'
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm/app/og-node/route.js
+++ b/tests/fixtures/wasm/app/og-node/route.js
@@ -6,3 +6,5 @@ export async function GET() {
     height: 630,
   })
 }
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm/app/og/route.js
+++ b/tests/fixtures/wasm/app/og/route.js
@@ -8,3 +8,5 @@ export async function GET() {
 }
 
 export const runtime = 'edge'
+
+export const dynamic = 'force-dynamic'


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Adjustment to `revalidate` tracking after https://github.com/vercel/next.js/pull/76207

## Tests

No new tests - we already have tests that were failing with latest/canary versions and this change make them pass again

Some unrelated test fixes:
1. For cache-status durable cache value changes
2. For windows failing to build fixtures on next@<15 ( problem described in https://github.com/opennextjs/opennextjs-netlify/pull/2772 as standalone, but might as well get it here in one go )