### PR TITLE
test: ensure we don't prerender API responses for og image in test fixture

### DIFF
--- a/tests/fixtures/wasm-src/src/app/og-node/route.js
+++ b/tests/fixtures/wasm-src/src/app/og-node/route.js
@@ -6,3 +6,5 @@ export async function GET() {
     height: 630,
   })
 }
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm-src/src/app/og/route.js
+++ b/tests/fixtures/wasm-src/src/app/og/route.js
@@ -8,3 +8,5 @@ export async function GET() {
 }
 
 export const runtime = 'edge'
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm/app/og-node/route.js
+++ b/tests/fixtures/wasm/app/og-node/route.js
@@ -6,3 +6,5 @@ export async function GET() {
     height: 630,
   })
 }
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/wasm/app/og/route.js
+++ b/tests/fixtures/wasm/app/og/route.js
@@ -8,3 +8,5 @@ export async function GET() {
 }
 
 export const runtime = 'edge'
+
+export const dynamic = 'force-dynamic'


### PR DESCRIPTION

## Description

There is some windows, recent node versions and `@vercel/og` problem which cause fixture sites build failure on next@<15 (versions that did cache Route handler responses by default) - like so https://github.com/opennextjs/opennextjs-netlify/actions/runs/13722271191/job/38380291401?pr=2771#step:12:247

This ensures our fixtures don't prerender those and instead we run those functions at runtime:
1. This fixes our windows test fixtures on next<@15 (making them behave like they do with next@>=15)
2. at actually test if those will render correctly in functions instead of making sure we serve cached responses (as we do have other, dedicated tests for that:
 - test fixture producing cacheable response ( https://github.com/opennextjs/opennextjs-netlify/blob/3301077e8dd902241f79bb983ea7b73509e8d982/tests/fixtures/server-components/app/api/revalidate-handler/route.ts )
 - test itself for it - https://github.com/opennextjs/opennextjs-netlify/blob/3301077e8dd902241f79bb983ea7b73509e8d982/tests/integration/cache-handler.test.ts#L385
