### PR TITLE
test: add test ensuring `GHSA-f82v-jwr5-mffw` doesn't affect Next.js on Netlify

### DIFF
--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -216,3 +216,19 @@ test.describe('Middleware with i18n and excluded paths', () => {
     })
   })
 })
+
+test("requests with x-middleware-subrequest don't skip middleware (GHSA-f82v-jwr5-mffw)", async ({
+  middlewareSubrequestVuln,
+}) => {
+  const response = await fetch(`${middlewareSubrequestVuln.url}`, {
+    headers: {
+      'x-middleware-subrequest': 'middleware:middleware:middleware:middleware:middleware',
+    },
+  })
+
+  // middleware was not skipped
+  expect(response.headers.get('x-test-used-middleware')).toBe('true')
+
+  // ensure we are testing version before the fix for self hosted
+  expect(response.headers.get('x-test-used-next-version')).toBe('15.2.2')
+})

--- a/tests/fixtures/middleware-subrequest-vuln/app/[[...wildcard]]/page.js
+++ b/tests/fixtures/middleware-subrequest-vuln/app/[[...wildcard]]/page.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Hi</h1>
+    </main>
+  )
+}

--- a/tests/fixtures/middleware-subrequest-vuln/app/layout.js
+++ b/tests/fixtures/middleware-subrequest-vuln/app/layout.js
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: 'Simple Next App',
+  description: 'Description for Simple Next App',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/tests/fixtures/middleware-subrequest-vuln/middleware.ts
+++ b/tests/fixtures/middleware-subrequest-vuln/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
+
+import packageJson from 'next/package.json'
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next()
+
+  response.headers.set('x-test-used-middleware', 'true')
+  response.headers.set('x-test-used-next-version', packageJson.version)
+
+  return response
+}

--- a/tests/fixtures/middleware-subrequest-vuln/next.config.js
+++ b/tests/fixtures/middleware-subrequest-vuln/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+}
+
+module.exports = nextConfig

--- a/tests/fixtures/middleware-subrequest-vuln/package.json
+++ b/tests/fixtures/middleware-subrequest-vuln/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "middleware-subrequest-vuln",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "next build",
+    "dev": "next dev",
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "15.2.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "test": {
+    "dependencies": {
+      "next": "15.2.2"
+    }
+  }
+}

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -333,6 +333,7 @@ export const fixtureFactories = {
   pnpm: () => createE2EFixture('pnpm', { packageManger: 'pnpm' }),
   bun: () => createE2EFixture('simple', { packageManger: 'bun' }),
   middleware: () => createE2EFixture('middleware'),
+  middlewareSubrequestVuln: () => createE2EFixture('middleware-subrequest-vuln'),
   middlewareI18nExcludedPaths: () => createE2EFixture('middleware-i18n-excluded-paths'),
   middlewareOg: () => createE2EFixture('middleware-og'),
   middlewarePages: () => createE2EFixture('middleware-pages'),


### PR DESCRIPTION
<!-- Provide a brief summary of the change. -->

### Documentation

This is ensuring Next.js apps hosted on Netlify are not affected by https://github.com/advisories/GHSA-f82v-jwr5-mffw

Our custom edge middleware implementation doesn't make use of `x-middleware-subrequest` header. But just for good measure - let's add test ensuring that suppling this header to request against app using vulnerable Next.js version (15.2.2, so one patch before fix for self hosted)