### PR TITLE
test: skip some vercel/next tests

### DIFF
--- a/tests/e2e-skip-retry.json
+++ b/tests/e2e-skip-retry.json
@@ -34,5 +34,6 @@
   "test/e2e/module-layer/index.test.ts",
   "test/e2e/prerender.test.ts",
   "test/e2e/react-compiler/react-compiler.test.ts",
-  "test/e2e/skip-trailing-slash-redirect/index.test.ts"
+  "test/e2e/skip-trailing-slash-redirect/index.test.ts",
+  "test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts"
 ]

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -370,6 +370,13 @@
         "app-root-params - generateStaticParams should be a cache hit for fully prerendered pages",
         "app-root-params - generateStaticParams should be a cache miss for pages that aren't prerendered"
       ]
+    },
+    {
+      "file": "test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts",
+      "reason": "Test is very flaky, and seems to test mostly browser behavior",
+      "tests": [
+        "router autoscrolling on navigation bugs Should apply scroll when loading.js is used"
+      ]
     }
   ],
   "failures": [

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -362,6 +362,14 @@
     {
       "file": "test/e2e/next-config-warnings/esm-externals-false/esm-externals-false.test.ts",
       "reason": "Uses CLI output"
+    },
+    {
+      "file": "test/e2e/app-dir/app-root-params/generate-static-params.test.ts",
+      "reason": "Checking Vercel specific x-vercel-cache header",
+      "tests": [
+        "app-root-params - generateStaticParams should be a cache hit for fully prerendered pages",
+        "app-root-params - generateStaticParams should be a cache miss for pages that aren't prerendered"
+      ]
     }
   ],
   "failures": [


### PR DESCRIPTION
## Description

Updating vercel/next.js test skiping:
 - 2 tests using `x-vercel-cache` response header for assertions
 - one flaky test that often times out in CI (which I couldn't reproduce locally) that seems to test Next's browser runtime more than any "server" handling

As part of this I also did create those tracking tickets that seems more warranted to have issues and not just be skipped (one of them seems flaky mostly due to test setup, but it does tests important functionality):
https://github.com/opennextjs/opennextjs-netlify/issues/2784
https://github.com/opennextjs/opennextjs-netlify/issues/2785

## Relevant links (GitHub issues, etc.) or a picture of cute animal

fixes https://linear.app/netlify/issue/FRB-1706/ensure-next-runtime-e2e-tests-page-has-no-unknown-failures
