### PR TITLE
fix: don't set permanent caching header when res.revalidate() was used

### DIFF
--- a/src/run/headers.ts
+++ b/src/run/headers.ts
@@ -266,7 +266,8 @@ export const setCacheControlHeaders = (
     ['GET', 'HEAD'].includes(request.method) &&
     !headers.has('cdn-cache-control') &&
     !headers.has('netlify-cdn-cache-control') &&
-    requestContext.usedFsReadForNonFallback
+    requestContext.usedFsReadForNonFallback &&
+    !requestContext.didPagesRouterOnDemandRevalidate
   ) {
     // handle CDN Cache Control on static files
     headers.set('cache-control', 'public, max-age=0, must-revalidate')

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -591,13 +591,19 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     ).toBeLessThan(10_000)
   })
 
-  test('API route calling res.revalidate() is not cacheable', async ({ page, pageRouter }) => {
+  test('API route calling res.revalidate() on page returning notFound: true is not cacheable', async ({
+    page,
+    pageRouter,
+  }) => {
+    // note: known conditions for problematic case is
+    // 1. API route needs to call res.revalidate()
+    // 2. revalidated page's getStaticProps must return notFound: true
     const response = await page.goto(
       new URL('/api/revalidate?path=/static/not-found', pageRouter.url).href,
     )
 
     expect(response?.status()).toEqual(200)
-    expect(response?.headers()['netlify-cdn-cache-control']).not.toMatch(/(s-maxage|max-age)/)
+    expect(response?.headers()['netlify-cdn-cache-control'] ?? '').not.toMatch(/(s-maxage|max-age)/)
   })
 })
 

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -590,6 +590,15 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
       'getStaticProps duration should not be longer than 10 seconds',
     ).toBeLessThan(10_000)
   })
+
+  test('API route calling res.revalidate() is not cacheable', async ({ page, pageRouter }) => {
+    const response = await page.goto(
+      new URL('/api/revalidate?path=/static/not-found', pageRouter.url).href,
+    )
+
+    expect(response?.status()).toEqual(200)
+    expect(response?.headers()['netlify-cdn-cache-control']).not.toMatch(/(s-maxage|max-age)/)
+  })
 })
 
 test.describe('Page Router with basePath and i18n', () => {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Our handling of setting permanent caching headers for fully static pages (pages router, no getStaticProps or getServerSideProps) is impacting other requests when it shouldn't - this focuses on case of api endpoints using `res.revalidate()` but is not fully solving it - it's meant as stop-gap solution to target pretty specific case.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added a test to verify that `res.revalidate()` endpoints are not cached

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Part of https://linear.app/netlify/issue/FRB-1707/next-runtime-is-sending-cdn-cache-control-headers-unexpectedly
