### PR TITLE
fix: handle case of zero-length cacheable route handler responses

### DIFF
--- a/src/run/storage/request-scoped-in-memory-cache.cts
+++ b/src/run/storage/request-scoped-in-memory-cache.cts
@@ -65,7 +65,6 @@ const estimateBlobKnownTypeSize = (
 }
 
 const estimateBlobSize = (valueToStore: BlobType | null | Promise<unknown>): PositiveNumber => {
-  let knownTypeFailed = false
   let estimatedKnownTypeSize: number | undefined
   let estimateBlobKnownTypeSizeError: unknown
   try {
@@ -74,21 +73,21 @@ const estimateBlobSize = (valueToStore: BlobType | null | Promise<unknown>): Pos
       return estimatedKnownTypeSize
     }
   } catch (error) {
-    knownTypeFailed = true
     estimateBlobKnownTypeSizeError = error
   }
 
   // fallback for not known kinds or known kinds that did fail to calculate positive size
+  const calculatedSize = JSON.stringify(valueToStore).length
+
   // we should also monitor cases when fallback is used because it's not the most efficient way to calculate/estimate size
   // and might indicate need to make adjustments or additions to the size calculation
   recordWarning(
     new Error(
-      `Blob size calculation did fallback to JSON.stringify. KnownTypeFailed: ${knownTypeFailed}, EstimatedKnownTypeSize: ${estimatedKnownTypeSize}, ValueToStore: ${JSON.stringify(valueToStore)}`,
+      `Blob size calculation did fallback to JSON.stringify. EstimatedKnownTypeSize: ${estimatedKnownTypeSize}, CalculatedSize: ${calculatedSize}, ValueToStore: ${JSON.stringify(valueToStore)}`,
       estimateBlobKnownTypeSizeError ? { cause: estimateBlobKnownTypeSizeError } : undefined,
     ),
   )
 
-  const calculatedSize = JSON.stringify(valueToStore).length
   return isPositiveNumber(calculatedSize) ? calculatedSize : BASE_BLOB_SIZE
 }
 

--- a/tests/fixtures/server-components/app/api/zero-length-response/route.ts
+++ b/tests/fixtures/server-components/app/api/zero-length-response/route.ts
@@ -1,0 +1,5 @@
+export async function GET() {
+  return new Response('')
+}
+
+export const dynamic = 'force-static'

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -508,4 +508,14 @@ describe('route', () => {
 
     expect(call2.body).toBe('{"params":{"slug":"not-in-generateStaticParams"}}')
   })
+
+  test<FixtureTestContext>('cacheable route handler response with 0 length response is served correctly', async (ctx) => {
+    await createFixture('server-components', ctx)
+    await runPlugin(ctx)
+
+    const call = await invokeFunction(ctx, { url: '/api/zero-length-response' })
+
+    expect(call.statusCode).toBe(200)
+    expect(call.body).toBe('')
+  })
 })

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -367,6 +367,7 @@ describe('plugin', () => {
       '/api/revalidate-handler',
       '/api/static/first',
       '/api/static/second',
+      '/api/zero-length-response',
       '/index',
       '/product/事前レンダリング,test',
       '/revalidate-fetch',


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Size calculcation for in-memory store in some cases was returning 0 (in particular known case is cacheable route handler with 0-length body).

This PR does few things:
 - ensure there is base blob size added to all known blob types so it should never return 0
 - add more checks to ensure fallback case also returns positive number
 - make crashes related to in-memory cache failures not fatal - this is meant to be optimization, but it should never cause handler to crash and lead to 500 errors. I did add warning reporting so we can spot those cases and adjust handling to get on happy path

## Tests

Added known case that is causing errors with currently released version

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1721/sizecalculation-return-invalid-expect-positive-integer
