### PR TITLE
fix: RSC responses when using middleware rewrites or redirects for cacheable page being served for html requests

### DIFF
--- a/tests/fixtures/middleware/app/caching-redirect-target/page.js
+++ b/tests/fixtures/middleware/app/caching-redirect-target/page.js
@@ -1,0 +1,9 @@
+export default function CachingRedirect() {
+  return (
+    <main>
+      <h1>Hello redirect target</h1>
+    </main>
+  )
+}
+
+export const dynamic = 'force-static'

--- a/tests/fixtures/middleware/app/caching-rewrite-target/page.js
+++ b/tests/fixtures/middleware/app/caching-rewrite-target/page.js
@@ -1,0 +1,9 @@
+export default function CachingRewrite() {
+  return (
+    <main>
+      <h1>Hello rewrite target</h1>
+    </main>
+  )
+}
+
+export const dynamic = 'force-static'

--- a/tests/fixtures/middleware/app/link-to-redirect-to-cached-page/page.js
+++ b/tests/fixtures/middleware/app/link-to-redirect-to-cached-page/page.js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function LinksToRedirectedCachedPage() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Link href="/test/redirect-to-cached-page">NextResponse.redirect</Link>
+        </li>
+      </ul>
+    </nav>
+  )
+}

--- a/tests/fixtures/middleware/app/link-to-rewrite-to-cached-page/page.js
+++ b/tests/fixtures/middleware/app/link-to-rewrite-to-cached-page/page.js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function LinksToRewrittenCachedPage() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Link href="/test/rewrite-to-cached-page">NextResponse.rewrite</Link>
+        </li>
+      </ul>
+    </nav>
+  )
+}

--- a/tests/fixtures/middleware/middleware.ts
+++ b/tests/fixtures/middleware/middleware.ts
@@ -80,6 +80,13 @@ const getResponse = (request: NextRequest) => {
     })
   }
 
+  if (request.nextUrl.pathname === '/test/rewrite-to-cached-page') {
+    return NextResponse.rewrite(new URL('/caching-rewrite-target', request.url))
+  }
+  if (request.nextUrl.pathname === '/test/redirect-to-cached-page') {
+    return NextResponse.redirect(new URL('/caching-redirect-target', request.url))
+  }
+
   return NextResponse.json({ error: 'Error' }, { status: 500 })
 }
 


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
