### PR TITLE
chore: generate provenance statements for npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   release-please:
@@ -35,7 +36,7 @@ jobs:
       - name: Build
         run: npm run build
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --provenance
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

https://docs.npmjs.com/generating-provenance-statements

This will add some additional information to npm increasing confidence in the package.

For some prior art - we already do have this configured for example for https://www.npmjs.com/package/@netlify/angular-runtime/v/2.3.1#provenance ("Provenance" section at the bottom of the page) which does add various links to how published version was built and released, linking to exact commit the version was built from etc