### PR TITLE
feat: support 'use cache'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "msw": "^2.0.7",
         "netlify-cli": "^20.1.1",
         "next": "^15.0.0-canary.28",
+        "next-with-cache-handler-v2": "npm:next@15.3.0-canary.13",
         "os": "^0.1.2",
         "outdent": "^0.8.0",
         "p-limit": "^5.0.0",
@@ -1578,10 +1579,11 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2896,450 +2898,380 @@
       "dev": true
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
-      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "glibc": ">=2.26",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.2"
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
-      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "glibc": ">=2.26",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.2"
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "macos": ">=11",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "macos": ">=10.13",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
-      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "glibc": ">=2.28",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
-      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "glibc": ">=2.26",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
-      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "glibc": ">=2.28",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
-      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "glibc": ">=2.26",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
-      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "musl": ">=1.2.2",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
-      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "musl": ">=1.2.2",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
-      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
-      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "glibc": ">=2.28",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.2"
+        "@img/sharp-libvips-linux-arm": "1.0.5"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
-      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "glibc": ">=2.26",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.2"
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
-      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "glibc": ">=2.31",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.2"
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
-      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "glibc": ">=2.26",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.2"
+        "@img/sharp-libvips-linux-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
-      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "musl": ">=1.2.2",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
-      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "musl": ">=1.2.2",
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
-      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
       "cpu": [
         "wasm32"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.1.1"
+        "@emnapi/runtime": "^1.2.0"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
-      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
-      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-        "npm": ">=9.6.5",
-        "pnpm": ">=7.1.0",
-        "yarn": ">=3.2.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -5954,6 +5886,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.11",
@@ -29606,6 +29545,215 @@
         }
       }
     },
+    "node_modules/next-with-cache-handler-v2": {
+      "name": "next",
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.0-canary.13.tgz",
+      "integrity": "sha512-c8BO/c1FjV/jY4OmlBTKaeI0YYDIsakkmJQFgpjq9RzoBetoi/VLAloZMDpsrfSFIhHDHhraLMxzSvS6mFKeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.3.0-canary.13",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.3.0-canary.13",
+        "@next/swc-darwin-x64": "15.3.0-canary.13",
+        "@next/swc-linux-arm64-gnu": "15.3.0-canary.13",
+        "@next/swc-linux-arm64-musl": "15.3.0-canary.13",
+        "@next/swc-linux-x64-gnu": "15.3.0-canary.13",
+        "@next/swc-linux-x64-musl": "15.3.0-canary.13",
+        "@next/swc-win32-arm64-msvc": "15.3.0-canary.13",
+        "@next/swc-win32-x64-msvc": "15.3.0-canary.13",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/env": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.0-canary.13.tgz",
+      "integrity": "sha512-JSc7jRSVdstjZ0bfxKMFeYM+gVRgUbPpGSWq9JLDQDH/mYHMN+LMNR8CafQCKjoSL7tzkBpH9Ug6r9WaIescCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-darwin-arm64": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.0-canary.13.tgz",
+      "integrity": "sha512-A1EiOZHBTFF3Asyb+h4R0/IuOFEx+HN/0ek9BwR7g4neqZunAMU0LaGeExhxX7eUDJR4NWV16HEQq6nBcJB/UA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.0-canary.13.tgz",
+      "integrity": "sha512-ojmJVrcv571Q893G0EZGgnYJOGjxYTYSvrNiXMaY2gz9W8p1G+wY/Fc6f2Vm5c2GQcjUdmJOb57x3Ujdxi3szw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.0-canary.13.tgz",
+      "integrity": "sha512-k4dEOZZ9x8PtHH8HtD/3h/epDBRqWOf13UOE3JY/NH60pY5t4uXG3JEj9tcKnezhv0/Q5eT9c6WiydXdjs2YvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.0-canary.13.tgz",
+      "integrity": "sha512-Ms7b0OF05Q2qpo90ih/cVhviNrEatVZtsobBVyoXGfWxv/gOrhXoxuzROFGNdGXRZNJ7EgUaWmO4pZGjfUhEWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.0-canary.13.tgz",
+      "integrity": "sha512-id/4NWejJpglZiY/PLpV0H675bITfo0QrUNjZtRuKfphJNkPoRGsMXdaZ3mSpFscTqofyaINQ3fis0D4sSmJUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.0-canary.13.tgz",
+      "integrity": "sha512-9eE2E6KN01yxwE9H2fWaQA6PRvfjuY+lvadGBpub/pf710kdWFe9VYb8zECT492Vw90axHmktFZDTXuf2WaVTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.0-canary.13.tgz",
+      "integrity": "sha512-PbJ/yFCUBxhLr6wKoaC+CQebzeaiqrYOJXEMb9O1XFWp2te8okLjF2BihSziFVLtoA4m2one56pG5jU7W9GUzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.0-canary.13.tgz",
+      "integrity": "sha512-6dUpH6huWVS0uBObUWBTolu/lZIP99oD1TdgjGt3S2te+OjXAlza8ERgR8mGTV04hpRZFv7tUivISaGlkYE+Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-with-cache-handler-v2/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -31793,44 +31941,44 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
-      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
-        "semver": "^7.6.0"
+        "semver": "^7.6.3"
       },
       "engines": {
-        "libvips": ">=8.15.2",
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.4",
-        "@img/sharp-darwin-x64": "0.33.4",
-        "@img/sharp-libvips-darwin-arm64": "1.0.2",
-        "@img/sharp-libvips-darwin-x64": "1.0.2",
-        "@img/sharp-libvips-linux-arm": "1.0.2",
-        "@img/sharp-libvips-linux-arm64": "1.0.2",
-        "@img/sharp-libvips-linux-s390x": "1.0.2",
-        "@img/sharp-libvips-linux-x64": "1.0.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
-        "@img/sharp-linux-arm": "0.33.4",
-        "@img/sharp-linux-arm64": "0.33.4",
-        "@img/sharp-linux-s390x": "0.33.4",
-        "@img/sharp-linux-x64": "0.33.4",
-        "@img/sharp-linuxmusl-arm64": "0.33.4",
-        "@img/sharp-linuxmusl-x64": "0.33.4",
-        "@img/sharp-wasm32": "0.33.4",
-        "@img/sharp-win32-ia32": "0.33.4",
-        "@img/sharp-win32-x64": "0.33.4"
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/sharp/node_modules/color": {
@@ -32832,10 +32980,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -35599,9 +35748,9 @@
       }
     },
     "@emnapi/runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-      "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -36362,162 +36511,162 @@
       "dev": true
     },
     "@img/sharp-darwin-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
-      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.2"
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
     "@img/sharp-darwin-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
-      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-darwin-x64": "1.0.2"
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
       }
     },
     "@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
-      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
-      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
-      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linux-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
-      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
-      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
-      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-linux-arm": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
-      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linux-arm": "1.0.2"
+        "@img/sharp-libvips-linux-arm": "1.0.5"
       }
     },
     "@img/sharp-linux-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
-      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linux-arm64": "1.0.2"
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
       }
     },
     "@img/sharp-linux-s390x": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
-      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linux-s390x": "1.0.2"
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
       }
     },
     "@img/sharp-linux-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
-      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linux-x64": "1.0.2"
+        "@img/sharp-libvips-linux-x64": "1.0.4"
       }
     },
     "@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
-      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
       }
     },
     "@img/sharp-linuxmusl-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
-      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "@img/sharp-wasm32": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
-      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@emnapi/runtime": "^1.1.1"
+        "@emnapi/runtime": "^1.2.0"
       }
     },
     "@img/sharp-win32-ia32": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
-      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
       "dev": true,
       "optional": true
     },
     "@img/sharp-win32-x64": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
-      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
       "dev": true,
       "optional": true
     },
@@ -38378,6 +38527,12 @@
       "requires": {
         "escape-string-regexp": "^5.0.0"
       }
+    },
+    "@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
     },
     "@swc/helpers": {
       "version": "0.5.11",
@@ -55065,6 +55220,103 @@
         "styled-jsx": "5.1.6"
       }
     },
+    "next-with-cache-handler-v2": {
+      "version": "npm:next@15.3.0-canary.13",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.0-canary.13.tgz",
+      "integrity": "sha512-c8BO/c1FjV/jY4OmlBTKaeI0YYDIsakkmJQFgpjq9RzoBetoi/VLAloZMDpsrfSFIhHDHhraLMxzSvS6mFKeuA==",
+      "dev": true,
+      "requires": {
+        "@next/env": "15.3.0-canary.13",
+        "@next/swc-darwin-arm64": "15.3.0-canary.13",
+        "@next/swc-darwin-x64": "15.3.0-canary.13",
+        "@next/swc-linux-arm64-gnu": "15.3.0-canary.13",
+        "@next/swc-linux-arm64-musl": "15.3.0-canary.13",
+        "@next/swc-linux-x64-gnu": "15.3.0-canary.13",
+        "@next/swc-linux-x64-musl": "15.3.0-canary.13",
+        "@next/swc-win32-arm64-msvc": "15.3.0-canary.13",
+        "@next/swc-win32-x64-msvc": "15.3.0-canary.13",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "sharp": "^0.33.5",
+        "styled-jsx": "5.1.6"
+      },
+      "dependencies": {
+        "@next/env": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.0-canary.13.tgz",
+          "integrity": "sha512-JSc7jRSVdstjZ0bfxKMFeYM+gVRgUbPpGSWq9JLDQDH/mYHMN+LMNR8CafQCKjoSL7tzkBpH9Ug6r9WaIescCw==",
+          "dev": true
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.0-canary.13.tgz",
+          "integrity": "sha512-A1EiOZHBTFF3Asyb+h4R0/IuOFEx+HN/0ek9BwR7g4neqZunAMU0LaGeExhxX7eUDJR4NWV16HEQq6nBcJB/UA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.0-canary.13.tgz",
+          "integrity": "sha512-ojmJVrcv571Q893G0EZGgnYJOGjxYTYSvrNiXMaY2gz9W8p1G+wY/Fc6f2Vm5c2GQcjUdmJOb57x3Ujdxi3szw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.0-canary.13.tgz",
+          "integrity": "sha512-k4dEOZZ9x8PtHH8HtD/3h/epDBRqWOf13UOE3JY/NH60pY5t4uXG3JEj9tcKnezhv0/Q5eT9c6WiydXdjs2YvQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.0-canary.13.tgz",
+          "integrity": "sha512-Ms7b0OF05Q2qpo90ih/cVhviNrEatVZtsobBVyoXGfWxv/gOrhXoxuzROFGNdGXRZNJ7EgUaWmO4pZGjfUhEWw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.0-canary.13.tgz",
+          "integrity": "sha512-id/4NWejJpglZiY/PLpV0H675bITfo0QrUNjZtRuKfphJNkPoRGsMXdaZ3mSpFscTqofyaINQ3fis0D4sSmJUw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.0-canary.13.tgz",
+          "integrity": "sha512-9eE2E6KN01yxwE9H2fWaQA6PRvfjuY+lvadGBpub/pf710kdWFe9VYb8zECT492Vw90axHmktFZDTXuf2WaVTA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.0-canary.13.tgz",
+          "integrity": "sha512-PbJ/yFCUBxhLr6wKoaC+CQebzeaiqrYOJXEMb9O1XFWp2te8okLjF2BihSziFVLtoA4m2one56pG5jU7W9GUzg==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "15.3.0-canary.13",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.0-canary.13.tgz",
+          "integrity": "sha512-6dUpH6huWVS0uBObUWBTolu/lZIP99oD1TdgjGt3S2te+OjXAlza8ERgR8mGTV04hpRZFv7tUivISaGlkYE+Bw==",
+          "dev": true,
+          "optional": true
+        },
+        "@swc/helpers": {
+          "version": "0.5.15",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+          "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        }
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -56617,34 +56869,34 @@
       }
     },
     "sharp": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
-      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@img/sharp-darwin-arm64": "0.33.4",
-        "@img/sharp-darwin-x64": "0.33.4",
-        "@img/sharp-libvips-darwin-arm64": "1.0.2",
-        "@img/sharp-libvips-darwin-x64": "1.0.2",
-        "@img/sharp-libvips-linux-arm": "1.0.2",
-        "@img/sharp-libvips-linux-arm64": "1.0.2",
-        "@img/sharp-libvips-linux-s390x": "1.0.2",
-        "@img/sharp-libvips-linux-x64": "1.0.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
-        "@img/sharp-linux-arm": "0.33.4",
-        "@img/sharp-linux-arm64": "0.33.4",
-        "@img/sharp-linux-s390x": "0.33.4",
-        "@img/sharp-linux-x64": "0.33.4",
-        "@img/sharp-linuxmusl-arm64": "0.33.4",
-        "@img/sharp-linuxmusl-x64": "0.33.4",
-        "@img/sharp-wasm32": "0.33.4",
-        "@img/sharp-win32-ia32": "0.33.4",
-        "@img/sharp-win32-x64": "0.33.4",
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5",
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
-        "semver": "^7.6.0"
+        "semver": "^7.6.3"
       },
       "dependencies": {
         "color": {
@@ -57393,9 +57645,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "msw": "^2.0.7",
     "netlify-cli": "^20.1.1",
     "next": "^15.0.0-canary.28",
+    "next-with-cache-handler-v2": "npm:next@15.3.0-canary.13",
     "os": "^0.1.2",
     "outdent": "^0.8.0",
     "p-limit": "^5.0.0",
@@ -89,13 +90,18 @@
     "uuid": "^10.0.0",
     "vitest": "^3.0.0"
   },
+  "overrides": {
+    "react": "19.0.0-rc.0",
+    "react-dom": "19.0.0-rc.0"
+  },
   "clean-package": {
     "indent": 2,
     "remove": [
       "clean-package",
       "dependencies",
       "devDependencies",
-      "scripts"
+      "scripts",
+      "overrides"
     ]
   }
 }

--- a/src/build/content/server.ts
+++ b/src/build/content/server.ts
@@ -34,7 +34,7 @@ function isError(error: unknown): error is NodeJS.ErrnoException {
  * Copy App/Pages Router Javascript needed by the server handler
  */
 export const copyNextServerCode = async (ctx: PluginContext): Promise<void> => {
-  return await tracer.withActiveSpan('copyNextServerCode', async () => {
+  await tracer.withActiveSpan('copyNextServerCode', async () => {
     // update the dist directory inside the required-server-files.json to work with
     // nx monorepos and other setups where the dist directory is modified
     const reqServerFilesPath = join(

--- a/src/build/content/server.ts
+++ b/src/build/content/server.ts
@@ -16,10 +16,11 @@ import { join as posixJoin, sep as posixSep } from 'node:path/posix'
 import { trace } from '@opentelemetry/api'
 import { wrapTracer } from '@opentelemetry/api/experimental'
 import glob from 'fast-glob'
-import { prerelease, lt as semverLowerThan, lte as semverLowerThanOrEqual } from 'semver'
+import { prerelease, satisfies, lt as semverLowerThan, lte as semverLowerThanOrEqual } from 'semver'
 
-import { RUN_CONFIG } from '../../run/constants.js'
-import { PluginContext } from '../plugin-context.js'
+import type { RunConfig } from '../../run/config.js'
+import { RUN_CONFIG_FILE } from '../../run/constants.js'
+import type { PluginContext, RequiredServerFilesManifest } from '../plugin-context.js'
 
 const tracer = wrapTracer(trace.getTracer('Next runtime'))
 
@@ -33,7 +34,7 @@ function isError(error: unknown): error is NodeJS.ErrnoException {
  * Copy App/Pages Router Javascript needed by the server handler
  */
 export const copyNextServerCode = async (ctx: PluginContext): Promise<void> => {
-  await tracer.withActiveSpan('copyNextServerCode', async () => {
+  return await tracer.withActiveSpan('copyNextServerCode', async () => {
     // update the dist directory inside the required-server-files.json to work with
     // nx monorepos and other setups where the dist directory is modified
     const reqServerFilesPath = join(
@@ -54,7 +55,9 @@ export const copyNextServerCode = async (ctx: PluginContext): Promise<void> => {
         throw error
       }
     }
-    const reqServerFiles = JSON.parse(await readFile(reqServerFilesPath, 'utf-8'))
+    const reqServerFiles = JSON.parse(
+      await readFile(reqServerFilesPath, 'utf-8'),
+    ) as RequiredServerFilesManifest
 
     // if the resolved dist folder does not match the distDir of the required-server-files.json
     // this means the path got altered by a plugin like nx and contained ../../ parts so we have to reset it
@@ -73,8 +76,17 @@ export const copyNextServerCode = async (ctx: PluginContext): Promise<void> => {
     // write our run-config.json to the root dir so that we can easily get the runtime config of the required-server-files.json
     // without the need to know about the monorepo or distDir configuration upfront.
     await writeFile(
-      join(ctx.serverHandlerDir, RUN_CONFIG),
-      JSON.stringify(reqServerFiles.config),
+      join(ctx.serverHandlerDir, RUN_CONFIG_FILE),
+      JSON.stringify({
+        nextConfig: reqServerFiles.config,
+        // only enable setting up 'use cache' handler when Next.js supports CacheHandlerV2 as we don't have V1 compatible implementation
+        // see https://github.com/vercel/next.js/pull/76687 first released in v15.3.0-canary.13
+        enableUseCacheHandler: ctx.nextVersion
+          ? satisfies(ctx.nextVersion, '>=15.3.0-canary.13', {
+              includePrerelease: true,
+            })
+          : false,
+      } satisfies RunConfig),
       'utf-8',
     )
 
@@ -336,9 +348,11 @@ const replaceMiddlewareManifest = async (sourcePath: string, destPath: string) =
 }
 
 export const verifyHandlerDirStructure = async (ctx: PluginContext) => {
-  const runConfig = JSON.parse(await readFile(join(ctx.serverHandlerDir, RUN_CONFIG), 'utf-8'))
+  const { nextConfig } = JSON.parse(
+    await readFile(join(ctx.serverHandlerDir, RUN_CONFIG_FILE), 'utf-8'),
+  ) as RunConfig
 
-  const expectedBuildIDPath = join(ctx.serverHandlerDir, runConfig.distDir, 'BUILD_ID')
+  const expectedBuildIDPath = join(ctx.serverHandlerDir, nextConfig.distDir, 'BUILD_ID')
   if (!existsSync(expectedBuildIDPath)) {
     ctx.failBuild(
       `Failed creating server handler. BUILD_ID file not found at expected location "${expectedBuildIDPath}".`,

--- a/src/run/config.ts
+++ b/src/run/config.ts
@@ -4,14 +4,19 @@ import { join, resolve } from 'node:path'
 
 import type { NextConfigComplete } from 'next/dist/server/config-shared.js'
 
-import { PLUGIN_DIR, RUN_CONFIG } from './constants.js'
+import { PLUGIN_DIR, RUN_CONFIG_FILE } from './constants.js'
 import { setInMemoryCacheMaxSizeFromNextConfig } from './storage/storage.cjs'
+
+export type RunConfig = {
+  nextConfig: NextConfigComplete
+  enableUseCacheHandler: boolean
+}
 
 /**
  * Get Next.js config from the build output
  */
 export const getRunConfig = async () => {
-  return JSON.parse(await readFile(resolve(PLUGIN_DIR, RUN_CONFIG), 'utf-8'))
+  return JSON.parse(await readFile(resolve(PLUGIN_DIR, RUN_CONFIG_FILE), 'utf-8')) as RunConfig
 }
 
 type NextConfigForMultipleVersions = NextConfigComplete & {

--- a/src/run/constants.ts
+++ b/src/run/constants.ts
@@ -4,4 +4,4 @@ import { fileURLToPath } from 'node:url'
 export const MODULE_DIR = fileURLToPath(new URL('.', import.meta.url))
 export const PLUGIN_DIR = resolve(`${MODULE_DIR}../../..`)
 // a file where we store the required-server-files config object in to access during runtime
-export const RUN_CONFIG = 'run-config.json'
+export const RUN_CONFIG_FILE = 'run-config.json'

--- a/src/run/handlers/tags-handler.cts
+++ b/src/run/handlers/tags-handler.cts
@@ -26,6 +26,27 @@ async function getTagRevalidatedAt(
 }
 
 /**
+ * Get the most recent revalidation timestamp for a list of tags
+ */
+export async function getMostRecentTagRevalidationTimestamp(tags: string[]) {
+  if (tags.length === 0) {
+    return 0
+  }
+
+  const cacheStore = getMemoizedKeyValueStoreBackedByRegionalBlobStore({ consistency: 'strong' })
+
+  const timestampsOrNulls = await Promise.all(
+    tags.map((tag) => getTagRevalidatedAt(tag, cacheStore)),
+  )
+
+  const timestamps = timestampsOrNulls.filter((timestamp) => timestamp !== null)
+  if (timestamps.length === 0) {
+    return 0
+  }
+  return Math.max(...timestamps)
+}
+
+/**
  * Check if any of the tags were invalidated since the given timestamp
  */
 export function isAnyTagStale(tags: string[], timestamp: number): Promise<boolean> {

--- a/src/run/handlers/use-cache-handler.ts
+++ b/src/run/handlers/use-cache-handler.ts
@@ -1,0 +1,270 @@
+import { Buffer } from 'node:buffer'
+
+import { LRUCache } from 'lru-cache'
+import type {
+  CacheEntry,
+  // only supporting latest variant (https://github.com/vercel/next.js/pull/76687)
+  // first released in v15.3.0-canary.13
+  CacheHandlerV2 as CacheHandler,
+} from 'next-with-cache-handler-v2/dist/server/lib/cache-handlers/types.js'
+
+import { getLogger } from './request-context.cjs'
+import {
+  getMostRecentTagRevalidationTimestamp,
+  isAnyTagStale,
+  markTagsAsStaleAndPurgeEdgeCache,
+} from './tags-handler.cjs'
+import { getTracer } from './tracer.cjs'
+
+// copied from default implementation
+// packages/next/src/server/lib/cache-handlers/default.ts
+type PrivateCacheEntry = {
+  entry: CacheEntry
+
+  // For the default cache we store errored cache
+  // entries and allow them to be used up to 3 times
+  // after that we want to dispose it and try for fresh
+
+  // If an entry is errored we return no entry
+  // three times so that we retry hitting origin (MISS)
+  // and then if it still fails to set after the third we
+  // return the errored content and use expiration of
+  // Math.min(30, entry.expiration)
+
+  isErrored: boolean // pieh: this doesn't seem to be actually used in the default implementation
+  errorRetryCount: number // pieh: this doesn't seem to be actually used in the default implementation
+
+  // compute size on set since we need to read size
+  // of the ReadableStream for LRU evicting
+  size: number
+}
+
+type CacheHandleLRUCache = LRUCache<string, PrivateCacheEntry>
+type PendingSets = Map<string, Promise<void>>
+
+const LRU_CACHE_GLOBAL_KEY = Symbol.for('nf-use-cache-handler-lru-cache')
+const PENDING_SETS_GLOBAL_KEY = Symbol.for('nf-use-cache-handler-pending-sets')
+const cacheHandlersSymbol = Symbol.for('@next/cache-handlers')
+const extendedGlobalThis = globalThis as typeof globalThis & {
+  // Used by Next Runtime to ensure we have single instance of
+  //  - LRUCache
+  //  - pending sets
+  // even if this module gets copied multiple times
+  [LRU_CACHE_GLOBAL_KEY]?: CacheHandleLRUCache
+  [PENDING_SETS_GLOBAL_KEY]?: PendingSets
+
+  // Used by Next.js to provide implementation of cache handlers
+  [cacheHandlersSymbol]?: {
+    RemoteCache?: CacheHandler
+    DefaultCache?: CacheHandler
+  }
+}
+
+function getLRUCache(): CacheHandleLRUCache {
+  if (extendedGlobalThis[LRU_CACHE_GLOBAL_KEY]) {
+    return extendedGlobalThis[LRU_CACHE_GLOBAL_KEY]
+  }
+
+  const lruCache = new LRUCache<string, PrivateCacheEntry>({
+    max: 1000,
+    maxSize: 50 * 1024 * 1024, // same as hardcoded default in Next.js
+    sizeCalculation: (value) => value.size,
+  })
+
+  extendedGlobalThis[LRU_CACHE_GLOBAL_KEY] = lruCache
+
+  return lruCache
+}
+
+function getPendingSets(): PendingSets {
+  if (extendedGlobalThis[PENDING_SETS_GLOBAL_KEY]) {
+    return extendedGlobalThis[PENDING_SETS_GLOBAL_KEY]
+  }
+
+  const pendingSets = new Map()
+  extendedGlobalThis[PENDING_SETS_GLOBAL_KEY] = pendingSets
+  return pendingSets
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const tmpResolvePendingBeforeCreatingAPromise = () => {}
+
+export const NetlifyDefaultUseCacheHandler = {
+  get(cacheKey: string): ReturnType<CacheHandler['get']> {
+    return getTracer().withActiveSpan(
+      'DefaultUseCacheHandler.get',
+      async (span): ReturnType<CacheHandler['get']> => {
+        getLogger().withFields({ cacheKey }).debug(`[NetlifyDefaultUseCacheHandler] get`)
+        span.setAttributes({
+          cacheKey,
+        })
+
+        const pendingPromise = getPendingSets().get(cacheKey)
+        if (pendingPromise) {
+          await pendingPromise
+        }
+
+        const privateEntry = getLRUCache().get(cacheKey)
+        if (!privateEntry) {
+          getLogger()
+            .withFields({ cacheKey, status: 'MISS' })
+            .debug(`[NetlifyDefaultUseCacheHandler] get result`)
+          span.setAttributes({
+            cacheStatus: 'miss',
+          })
+          return undefined
+        }
+
+        const { entry } = privateEntry
+        const ttl = (entry.timestamp + entry.revalidate * 1000 - Date.now()) / 1000
+        if (ttl < 0) {
+          // In-memory caches should expire after revalidate time because it is
+          // unlikely that a new entry will be able to be used before it is dropped
+          // from the cache.
+          getLogger()
+            .withFields({ cacheKey, ttl, status: 'STALE' })
+            .debug(`[NetlifyDefaultUseCacheHandler] get result`)
+          span.setAttributes({
+            cacheStatus: 'expired, discarded',
+            ttl,
+          })
+          return undefined
+        }
+
+        if (await isAnyTagStale(entry.tags, entry.timestamp)) {
+          getLogger()
+            .withFields({ cacheKey, ttl, status: 'STALE BY TAG' })
+            .debug(`[NetlifyDefaultUseCacheHandler] get result`)
+
+          span.setAttributes({
+            cacheStatus: 'stale tag, discarded',
+            ttl,
+          })
+          return undefined
+        }
+
+        // returning entry will cause stream to be consumed
+        // so we need to clone it first, so in-memory cache can
+        // be used again
+        const [returnStream, newSaved] = entry.value.tee()
+        entry.value = newSaved
+
+        getLogger()
+          .withFields({ cacheKey, ttl, status: 'HIT' })
+          .debug(`[NetlifyDefaultUseCacheHandler] get result`)
+        span.setAttributes({
+          cacheStatus: 'hit',
+          ttl,
+        })
+
+        return {
+          ...entry,
+          value: returnStream,
+        }
+      },
+    )
+  },
+  set(cacheKey: string, pendingEntry: Promise<CacheEntry>): ReturnType<CacheHandler['set']> {
+    return getTracer().withActiveSpan(
+      'DefaultUseCacheHandler.set',
+      async (span): ReturnType<CacheHandler['set']> => {
+        getLogger().withFields({ cacheKey }).debug(`[NetlifyDefaultUseCacheHandler]: set`)
+        span.setAttributes({
+          cacheKey,
+        })
+
+        let resolvePending: () => void = tmpResolvePendingBeforeCreatingAPromise
+        const pendingPromise = new Promise<void>((resolve) => {
+          resolvePending = resolve
+        })
+
+        const pendingSets = getPendingSets()
+
+        pendingSets.set(cacheKey, pendingPromise)
+
+        const entry = await pendingEntry
+
+        span.setAttributes({
+          cacheKey,
+        })
+
+        let size = 0
+        try {
+          const [value, clonedValue] = entry.value.tee()
+          entry.value = value
+          const reader = clonedValue.getReader()
+
+          for (let chunk; !(chunk = await reader.read()).done; ) {
+            size += Buffer.from(chunk.value).byteLength
+          }
+
+          span.setAttributes({
+            tags: entry.tags,
+            timestamp: entry.timestamp,
+            revalidate: entry.revalidate,
+            expire: entry.expire,
+          })
+
+          getLRUCache().set(cacheKey, {
+            entry,
+            isErrored: false,
+            errorRetryCount: 0,
+            size,
+          })
+        } catch (error) {
+          getLogger().withError(error).error('[NetlifyDefaultUseCacheHandler.set] error')
+        } finally {
+          resolvePending()
+          pendingSets.delete(cacheKey)
+        }
+      },
+    )
+  },
+  async refreshTags(): Promise<void> {
+    // we check tags on demand, so we don't need to do anything here
+    // additionally this is blocking and we do need to check tags in
+    // persisted storage, so if we would maintain in-memory tags manifests
+    // we would need to check more tags than current request needs
+    // while blocking pipeline
+  },
+  getExpiration: function (...tags: string[]): ReturnType<CacheHandler['getExpiration']> {
+    return getTracer().withActiveSpan(
+      'DefaultUseCacheHandler.getExpiration',
+      async (span): ReturnType<CacheHandler['getExpiration']> => {
+        span.setAttributes({
+          tags,
+        })
+
+        const expiration = await getMostRecentTagRevalidationTimestamp(tags)
+
+        getLogger()
+          .withFields({ tags, expiration })
+          .debug(`[NetlifyDefaultUseCacheHandler] getExpiration`)
+        span.setAttributes({
+          expiration,
+        })
+
+        return expiration
+      },
+    )
+  },
+  expireTags(...tags: string[]): ReturnType<CacheHandler['expireTags']> {
+    return getTracer().withActiveSpan(
+      'DefaultUseCacheHandler.expireTags',
+      async (span): ReturnType<CacheHandler['expireTags']> => {
+        getLogger().withFields({ tags }).debug(`[NetlifyDefaultUseCacheHandler] expireTags`)
+        span.setAttributes({
+          tags,
+        })
+
+        await markTagsAsStaleAndPurgeEdgeCache(tags)
+      },
+    )
+  },
+} satisfies CacheHandler
+
+export function configureUseCacheHandlers() {
+  extendedGlobalThis[cacheHandlersSymbol] = {
+    DefaultCache: NetlifyDefaultUseCacheHandler,
+  }
+}

--- a/tests/fixtures/use-cache/app/api/revalidate/[...slug]/route.ts
+++ b/tests/fixtures/use-cache/app/api/revalidate/[...slug]/route.ts
@@ -1,0 +1,12 @@
+import { revalidateTag } from 'next/cache'
+import { NextRequest } from 'next/server'
+
+export async function GET(request: NextRequest, { params }) {
+  const { slug } = await params
+
+  const tagToInvalidate = slug.join('/')
+
+  revalidateTag(tagToInvalidate)
+
+  return Response.json({ tagToInvalidate })
+}

--- a/tests/fixtures/use-cache/app/default/use-cache-component/dynamic/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-component/dynamic/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  'use cache'
+  cacheTag(`component/${props.route}`)
+  cacheLife('1year')
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-component/dynamic/ttl-1year"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-component/dynamic/ttl-5seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-component/dynamic/ttl-5seconds/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  'use cache'
+  cacheTag(`component/${props.route}`)
+  cacheLife('5seconds')
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-component/dynamic/ttl-5seconds"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-component/static/ttl-10seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-component/static/ttl-10seconds/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  'use cache'
+  cacheTag(`component/${props.route}`)
+  cacheLife('10seconds') // longer TTL than page revalidate to test interaction
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-component/static/ttl-10seconds"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const revalidate = 5
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/default/use-cache-component/static/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-component/static/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,37 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  'use cache'
+  cacheTag(`component/${props.route}`)
+  cacheLife('1year')
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-component/static/ttl-1year"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/default/use-cache-data/dynamic/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-data/dynamic/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,33 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  'use cache'
+  cacheTag(`data/${route}`)
+  cacheLife('1year')
+
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-data/dynamic/ttl-1year"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-data/dynamic/ttl-5seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-data/dynamic/ttl-5seconds/[slug]/page.tsx
@@ -1,0 +1,33 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  'use cache'
+  cacheTag(`data/${route}`)
+  cacheLife('5seconds')
+
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-data/dynamic/ttl-5seconds"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-data/static/ttl-10seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-data/static/ttl-10seconds/[slug]/page.tsx
@@ -1,0 +1,39 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  'use cache'
+  cacheTag(`data/${route}`)
+  cacheLife('10seconds') // longer TTL than page revalidate to test interaction
+
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-data/static/ttl-10seconds"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const revalidate = 5
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/default/use-cache-data/static/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-data/static/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  'use cache'
+  cacheTag(`data/${route}`)
+  cacheLife('1year')
+
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  return (
+    <PageComponentImplementation
+      routeRoot="default/use-cache-data/static/ttl-1year"
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/default/use-cache-page/dynamic/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-page/dynamic/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  'use cache'
+  const routeRoot = 'default/use-cache-page/dynamic/ttl-1year'
+  cacheTag(`page/${routeRoot}/${(await params).slug}`)
+  cacheLife('1year')
+
+  return (
+    <PageComponentImplementation
+      routeRoot={routeRoot}
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-page/dynamic/ttl-5seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-page/dynamic/ttl-5seconds/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  'use cache'
+  const routeRoot = 'default/use-cache-page/dynamic/ttl-5seconds'
+  cacheTag(`page/${routeRoot}/${(await params).slug}`)
+  cacheLife('5seconds')
+
+  return (
+    <PageComponentImplementation
+      routeRoot={routeRoot}
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/tests/fixtures/use-cache/app/default/use-cache-page/static/ttl-10seconds/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-page/static/ttl-10seconds/[slug]/page.tsx
@@ -1,0 +1,39 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  'use cache'
+  const routeRoot = 'default/use-cache-page/static/ttl-10seconds'
+  cacheTag(`page/${routeRoot}/${(await params).slug}`)
+  cacheLife('10seconds') // longer TTL than page revalidate to test interaction
+  return (
+    <PageComponentImplementation
+      routeRoot={routeRoot}
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const revalidate = 5
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/default/use-cache-page/static/ttl-1year/[slug]/page.tsx
+++ b/tests/fixtures/use-cache/app/default/use-cache-page/static/ttl-1year/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag } from 'next/cache'
+import {
+  BasePageComponentProps,
+  generateStaticParamsImplementation,
+  getDataImplementation,
+  PageComponentImplementation,
+  ResultComponentImplementation,
+  ResultWrapperComponentProps,
+} from '../../../../../helpers'
+
+async function getData(route: string) {
+  return await getDataImplementation(route)
+}
+
+async function ResultWrapperComponent(props: ResultWrapperComponentProps) {
+  return <ResultComponentImplementation {...props} />
+}
+
+export default async function PageComponent({ params }: BasePageComponentProps) {
+  'use cache'
+  const routeRoot = 'default/use-cache-page/static/ttl-1year'
+  cacheTag(`page/${routeRoot}/${(await params).slug}`)
+  cacheLife('1year')
+  return (
+    <PageComponentImplementation
+      routeRoot={routeRoot}
+      params={params}
+      getData={getData}
+      ResultWrapperComponent={ResultWrapperComponent}
+    />
+  )
+}
+
+export function generateStaticParams() {
+  return generateStaticParamsImplementation()
+}
+
+export const dynamic = 'force-static'

--- a/tests/fixtures/use-cache/app/helpers.tsx
+++ b/tests/fixtures/use-cache/app/helpers.tsx
@@ -1,0 +1,73 @@
+export type Data = {
+  data: string
+  time: string
+}
+
+export async function getDataImplementation(route: string): Promise<Data> {
+  const res = await fetch(`https://strangerthings-quotes.vercel.app/api/quotes`)
+  return {
+    data: (await res.json())[0].quote,
+    time: new Date().toISOString(),
+  }
+}
+
+export type ResultWrapperComponentProps = {
+  route: string
+  children: React.ReactNode
+}
+
+export async function ResultComponentImplementation({
+  route,
+  children,
+}: ResultWrapperComponentProps) {
+  return (
+    <>
+      {children}
+      <dt>Time (GetDataResult)</dt>
+      <dd data-testid="ResultWrapperComponent-time">{new Date().toISOString()}</dd>
+    </>
+  )
+}
+
+export type BasePageComponentProps = {
+  params: Promise<{ slug: string }>
+}
+
+export async function PageComponentImplementation({
+  getData,
+  ResultWrapperComponent,
+  params,
+  routeRoot,
+}: BasePageComponentProps & {
+  routeRoot: string
+  getData: typeof getDataImplementation
+  ResultWrapperComponent: typeof ResultComponentImplementation
+}) {
+  const { slug } = await params
+  const route = `${routeRoot}/${slug}`
+  const { data, time } = await getData(route)
+
+  return (
+    <>
+      <h1>Hello, use-cache - {route}</h1>
+      <dl>
+        <ResultWrapperComponent route={route}>
+          <dt>Quote (getData)</dt>
+          <dd data-testid="getData-data">{data}</dd>
+          <dt>Time (getData)</dt>
+          <dd data-testid="getData-time">{time}</dd>
+        </ResultWrapperComponent>
+        <dt>Time (PageComponent)</dt>
+        <dd data-testid="PageComponent-time">{new Date().toISOString()}</dd>
+      </dl>
+    </>
+  )
+}
+
+export function generateStaticParamsImplementation() {
+  return [
+    {
+      slug: 'prerendered',
+    },
+  ]
+}

--- a/tests/fixtures/use-cache/app/layout.js
+++ b/tests/fixtures/use-cache/app/layout.js
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: 'Use cache App',
+  description: 'Description for Use cache Next App',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/tests/fixtures/use-cache/next-env.d.ts
+++ b/tests/fixtures/use-cache/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/fixtures/use-cache/next.config.js
+++ b/tests/fixtures/use-cache/next.config.js
@@ -1,0 +1,35 @@
+const INFINITE_CACHE = 0xfffffffe
+
+const ONE_YEAR = 365 * 24 * 60 * 60
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'standalone',
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  experimental: {
+    useCache: true,
+    cacheLife: {
+      '5seconds': {
+        stale: 5,
+        revalidate: 5,
+        expire: INFINITE_CACHE,
+      },
+      '10seconds': {
+        stale: 10,
+        revalidate: 10,
+        expire: INFINITE_CACHE,
+      },
+      '1year': {
+        stale: ONE_YEAR,
+        revalidate: ONE_YEAR,
+        expire: INFINITE_CACHE,
+      },
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/tests/fixtures/use-cache/package.json
+++ b/tests/fixtures/use-cache/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "use-cache",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "next build",
+    "dev": "next dev",
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.1.2"
+  },
+  "test": {
+    "dependencies": {
+      "next": ">=15.3.0-canary.13"
+    }
+  }
+}

--- a/tests/fixtures/use-cache/tsconfig.json
+++ b/tests/fixtures/use-cache/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tests/integration/use-cache.test.ts
+++ b/tests/integration/use-cache.test.ts
@@ -42,7 +42,7 @@ function compareDates(
 }
 
 type ExpectedCachingBehaviorDefinition = {
-  getDataTimeShouldShouldBeEqual: boolean
+  getDataTimeShouldBeEqual: boolean
   resultWrapperComponentTimeShouldBeEqual: boolean
   pageComponentTimeShouldBeEqual: boolean
 }
@@ -87,7 +87,7 @@ expect.extend({
     response1: Awaited<InvokeFunctionResult>,
     response2: Awaited<InvokeFunctionResult>,
     {
-      getDataTimeShouldShouldBeEqual,
+      getDataTimeShouldBeEqual,
       resultWrapperComponentTimeShouldBeEqual,
       pageComponentTimeShouldBeEqual,
     }: ExpectedCachingBehaviorDefinition,
@@ -99,7 +99,7 @@ expect.extend({
       $response1,
       $response2,
       'getData-time',
-      getDataTimeShouldShouldBeEqual,
+      getDataTimeShouldBeEqual,
       this.utils.diff,
     )
     const resultComponentComparison = compareDates(
@@ -186,7 +186,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
         useCacheTagPrefix: 'data',
         expectedCachingBehaviorWhenUseCacheRegenerates: {
           // getData function has 'use cache' so it should report same generation time, everything else is dynamically regenerated on each request
-          getDataTimeShouldShouldBeEqual: true,
+          getDataTimeShouldBeEqual: true,
           resultWrapperComponentTimeShouldBeEqual: false,
           pageComponentTimeShouldBeEqual: false,
         },
@@ -197,7 +197,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
         useCacheTagPrefix: 'component',
         expectedCachingBehaviorWhenUseCacheRegenerates: {
           // <ResultWrapperComponent> has 'use cache' so it should report same generation time, everything else is dynamically regenerated on each request
-          getDataTimeShouldShouldBeEqual: false,
+          getDataTimeShouldBeEqual: false,
           resultWrapperComponentTimeShouldBeEqual: true,
           pageComponentTimeShouldBeEqual: false,
         },
@@ -208,7 +208,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
         useCacheTagPrefix: 'page',
         expectedCachingBehaviorWhenUseCacheRegenerates: {
           // <PageComponent> has 'use cache' so it should report same generation time for everything as this is entry point
-          getDataTimeShouldShouldBeEqual: true,
+          getDataTimeShouldBeEqual: true,
           resultWrapperComponentTimeShouldBeEqual: true,
           pageComponentTimeShouldBeEqual: true,
         },
@@ -247,7 +247,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
               const call2 = await invokeFunction({ url })
               expect(call2).toHaveExpectedCachingBehavior(call1, {
                 // getData function has 'use cache', but it was on-demand revalidated so everything should be fresh
-                getDataTimeShouldShouldBeEqual: false,
+                getDataTimeShouldBeEqual: false,
                 resultWrapperComponentTimeShouldBeEqual: false,
                 pageComponentTimeShouldBeEqual: false,
               })
@@ -265,7 +265,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
               const call2 = await invokeFunctionLambda2({ url })
               expect(call2).toHaveExpectedCachingBehavior(call1, {
                 // default cache is in-memory so we expect lambdas not to share data
-                getDataTimeShouldShouldBeEqual: false,
+                getDataTimeShouldBeEqual: false,
                 resultWrapperComponentTimeShouldBeEqual: false,
                 pageComponentTimeShouldBeEqual: false,
               })
@@ -285,7 +285,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
               const call2 = await invokeFunctionLambda1({ url })
               expect(call2).toHaveExpectedCachingBehavior(call1, {
                 // invalidation done by lambda2 should invalidate lambda1 as well
-                getDataTimeShouldShouldBeEqual: false,
+                getDataTimeShouldBeEqual: false,
                 resultWrapperComponentTimeShouldBeEqual: false,
                 pageComponentTimeShouldBeEqual: false,
               })
@@ -316,7 +316,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
               const call3 = await invokeFunction({ url })
               expect(call3).toHaveExpectedCachingBehavior(call2, {
                 // cache should expire and fresh content should be generated
-                getDataTimeShouldShouldBeEqual: false,
+                getDataTimeShouldBeEqual: false,
                 resultWrapperComponentTimeShouldBeEqual: false,
                 pageComponentTimeShouldBeEqual: false,
               })
@@ -361,7 +361,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
 
                   expect(call2).toHaveExpectedCachingBehavior(call1, {
                     // response is served from response cache and `use cache` is not even actually used
-                    getDataTimeShouldShouldBeEqual: true,
+                    getDataTimeShouldBeEqual: true,
                     resultWrapperComponentTimeShouldBeEqual: true,
                     pageComponentTimeShouldBeEqual: true,
                   })
@@ -375,7 +375,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
 
                   expect(call3).toHaveExpectedCachingBehavior(call2, {
                     // invalidation shot result in everything changing
-                    getDataTimeShouldShouldBeEqual: false,
+                    getDataTimeShouldBeEqual: false,
                     resultWrapperComponentTimeShouldBeEqual: false,
                     pageComponentTimeShouldBeEqual: false,
                   })
@@ -405,7 +405,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
 
                   expect(call2).toHaveExpectedCachingBehavior(call1, {
                     // response is served from response cache and `use cache` is not even actually used
-                    getDataTimeShouldShouldBeEqual: true,
+                    getDataTimeShouldBeEqual: true,
                     resultWrapperComponentTimeShouldBeEqual: true,
                     pageComponentTimeShouldBeEqual: true,
                   })
@@ -416,7 +416,7 @@ describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => 
                   const call3 = await invokeFunction({ url })
                   expect(call3).toHaveExpectedCachingBehavior(call2, {
                     // still stale content on first request after invalidation
-                    getDataTimeShouldShouldBeEqual: true,
+                    getDataTimeShouldBeEqual: true,
                     resultWrapperComponentTimeShouldBeEqual: true,
                     pageComponentTimeShouldBeEqual: true,
                   })

--- a/tests/integration/use-cache.test.ts
+++ b/tests/integration/use-cache.test.ts
@@ -1,0 +1,429 @@
+import { CheerioAPI, load } from 'cheerio'
+import { getLogger } from 'lambda-local'
+import { v4 } from 'uuid'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { type FixtureTestContext } from '../utils/contexts.js'
+import { createFixture, loadSandboxedFunction, runPlugin } from '../utils/fixture.js'
+import { generateRandomObjectID, startMockBlobStore } from '../utils/helpers.js'
+import { InvokeFunctionResult } from '../utils/lambda-helpers.mjs'
+import { nextVersionSatisfies } from '../utils/next-version-helpers.mjs'
+
+function compareDates(
+  $response1: CheerioAPI,
+  $response2: CheerioAPI,
+  testid: string,
+  shouldBeEqual: boolean,
+  diffHelper: (a: string, b: string) => string | undefined,
+) {
+  const selector = `[data-testid="${testid}"]`
+
+  const data1 = $response1(selector).text()
+  const data2 = $response2(selector).text()
+
+  if (!data1 || !data2) {
+    return {
+      isExpected: false,
+      msg: `Missing or empty data-testid="${testid}" in one of the responses`,
+    }
+  }
+
+  const isEqual = data1 === data2
+  const isExpected = isEqual === shouldBeEqual
+
+  return {
+    isExpected,
+    msg: isExpected
+      ? null
+      : shouldBeEqual
+        ? `Expected ${testid} to be equal, but got different values:\n${diffHelper(data1, data2)}`
+        : `Expected ${testid} NOT to be equal, but got same value: "${data1}`,
+  }
+}
+
+type ExpectedCachingBehaviorDefinition = {
+  getDataTimeShouldShouldBeEqual: boolean
+  resultWrapperComponentTimeShouldBeEqual: boolean
+  pageComponentTimeShouldBeEqual: boolean
+}
+
+expect.extend({
+  toBeCacheableResponse(response: Awaited<InvokeFunctionResult>) {
+    const netlifyCacheControlHeader = response.headers['netlify-cdn-cache-control']
+
+    if (typeof netlifyCacheControlHeader !== 'string') {
+      return {
+        pass: false,
+        message: () =>
+          `Expected 'netlify-cdn-cache-control' response header to be a string. Got ${netlifyCacheControlHeader} (${typeof netlifyCacheControlHeader}).`,
+      }
+    }
+
+    const isCacheable = Boolean(netlifyCacheControlHeader.match(/(max-age|s-maxage)(?!=0)/))
+
+    return {
+      pass: isCacheable,
+      message: () =>
+        `Expected ${netlifyCacheControlHeader} to${this.isNot ? ' not' : ''} be cacheable`,
+    }
+  },
+  toHaveResponseCacheTag(response: Awaited<InvokeFunctionResult>, tag: string) {
+    const netlifyCacheTag = response.headers['netlify-cache-tag']
+    if (typeof netlifyCacheTag !== 'string') {
+      return {
+        pass: false,
+        message: () =>
+          `Expected 'netlify-cache-tag' response header to be a string. Got ${netlifyCacheTag} (${typeof netlifyCacheTag}).`,
+      }
+    }
+    const containsTag = Boolean(netlifyCacheTag.split(',').find((t) => t.trim() === tag))
+
+    return {
+      pass: containsTag,
+      message: () => `Expected ${netlifyCacheTag} to${this.isNot ? ' not' : ''} have "${tag}" tag`,
+    }
+  },
+  toHaveExpectedCachingBehavior(
+    response1: Awaited<InvokeFunctionResult>,
+    response2: Awaited<InvokeFunctionResult>,
+    {
+      getDataTimeShouldShouldBeEqual,
+      resultWrapperComponentTimeShouldBeEqual,
+      pageComponentTimeShouldBeEqual,
+    }: ExpectedCachingBehaviorDefinition,
+  ) {
+    const $response1 = load(response1.body)
+    const $response2 = load(response2.body)
+
+    const getDataComparison = compareDates(
+      $response1,
+      $response2,
+      'getData-time',
+      getDataTimeShouldShouldBeEqual,
+      this.utils.diff,
+    )
+    const resultComponentComparison = compareDates(
+      $response1,
+      $response2,
+      'ResultWrapperComponent-time',
+      resultWrapperComponentTimeShouldBeEqual,
+      this.utils.diff,
+    )
+    const pageComponentComparison = compareDates(
+      $response1,
+      $response2,
+      'PageComponent-time',
+      pageComponentTimeShouldBeEqual,
+      this.utils.diff,
+    )
+
+    return {
+      pass:
+        getDataComparison.isExpected &&
+        resultComponentComparison.isExpected &&
+        pageComponentComparison.isExpected,
+      message: () =>
+        [getDataComparison.msg, resultComponentComparison.msg, pageComponentComparison.msg]
+          .filter(Boolean)
+          .join('\n\n'),
+    }
+  },
+})
+
+interface CustomMatchers<R = unknown> {
+  toBeCacheableResponse(): R
+  toHaveResponseCacheTag(tag: string): R
+  toHaveExpectedCachingBehavior(
+    response2: Awaited<InvokeFunctionResult>,
+    expectations: ExpectedCachingBehaviorDefinition,
+  ): R
+}
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+}
+
+// Disable the verbose logging of the lambda-local runtime
+getLogger().level = 'alert'
+
+let ctx: FixtureTestContext
+beforeAll(async () => {
+  ctx = {
+    deployID: generateRandomObjectID(),
+    siteID: v4(),
+  } as FixtureTestContext
+
+  vi.stubEnv('SITE_ID', ctx.siteID)
+  vi.stubEnv('DEPLOY_ID', ctx.deployID)
+  vi.stubEnv('NETLIFY_PURGE_API_TOKEN', 'fake-token')
+  await startMockBlobStore(ctx as FixtureTestContext)
+
+  await createFixture('use-cache', ctx)
+  await runPlugin(ctx)
+})
+
+// only supporting latest variant (https://github.com/vercel/next.js/pull/76687)
+// first released in v15.3.0-canary.13 so we should not run tests on older next versions
+describe.skipIf(!nextVersionSatisfies('>=15.3.0-canary.13'))('use cache', () => {
+  describe('default (in-memory cache entries, shared tag manifests)', () => {
+    for (const {
+      expectedCachingBehaviorWhenUseCacheRegenerates,
+      useCacheLocationLabel,
+      useCacheLocationPathSegment,
+      useCacheTagPrefix,
+    } of [
+      {
+        useCacheLocationLabel: "'use cache' in data fetching function",
+        useCacheLocationPathSegment: 'use-cache-data',
+        useCacheTagPrefix: 'data',
+        expectedCachingBehaviorWhenUseCacheRegenerates: {
+          // getData function has 'use cache' so it should report same generation time, everything else is dynamically regenerated on each request
+          getDataTimeShouldShouldBeEqual: true,
+          resultWrapperComponentTimeShouldBeEqual: false,
+          pageComponentTimeShouldBeEqual: false,
+        },
+      },
+      {
+        useCacheLocationLabel: "'use cache' in react non-page component",
+        useCacheLocationPathSegment: 'use-cache-component',
+        useCacheTagPrefix: 'component',
+        expectedCachingBehaviorWhenUseCacheRegenerates: {
+          // <ResultWrapperComponent> has 'use cache' so it should report same generation time, everything else is dynamically regenerated on each request
+          getDataTimeShouldShouldBeEqual: false,
+          resultWrapperComponentTimeShouldBeEqual: true,
+          pageComponentTimeShouldBeEqual: false,
+        },
+      },
+      {
+        useCacheLocationLabel: "'use cache' in react page component",
+        useCacheLocationPathSegment: 'use-cache-page',
+        useCacheTagPrefix: 'page',
+        expectedCachingBehaviorWhenUseCacheRegenerates: {
+          // <PageComponent> has 'use cache' so it should report same generation time for everything as this is entry point
+          getDataTimeShouldShouldBeEqual: true,
+          resultWrapperComponentTimeShouldBeEqual: true,
+          pageComponentTimeShouldBeEqual: true,
+        },
+      },
+    ]) {
+      describe(useCacheLocationLabel, () => {
+        describe('dynamic page (not using response cache)', () => {
+          describe('TTL=1 year', () => {
+            const routeRoot = `default/${useCacheLocationPathSegment}/dynamic/ttl-1year`
+
+            test<FixtureTestContext>('subsequent invocations on same lambda return same result', async () => {
+              const url = `${routeRoot}/same-lambda`
+
+              const { invokeFunction } = await loadSandboxedFunction(ctx)
+
+              const call1 = await invokeFunction({ url })
+              expect(call1).not.toBeCacheableResponse()
+
+              const call2 = await invokeFunction({ url })
+              expect(call2).toHaveExpectedCachingBehavior(
+                call1,
+                expectedCachingBehaviorWhenUseCacheRegenerates,
+              )
+            })
+
+            test<FixtureTestContext>('tag invalidation works on same lambda', async () => {
+              const url = `${routeRoot}/same-lambda-tag-invalidation`
+
+              const { invokeFunction } = await loadSandboxedFunction(ctx)
+
+              const call1 = await invokeFunction({ url })
+              expect(call1).not.toBeCacheableResponse()
+
+              await invokeFunction({ url: `/api/revalidate/${useCacheTagPrefix}/${url}` })
+
+              const call2 = await invokeFunction({ url })
+              expect(call2).toHaveExpectedCachingBehavior(call1, {
+                // getData function has 'use cache', but it was on-demand revalidated so everything should be fresh
+                getDataTimeShouldShouldBeEqual: false,
+                resultWrapperComponentTimeShouldBeEqual: false,
+                pageComponentTimeShouldBeEqual: false,
+              })
+            })
+
+            test<FixtureTestContext>('invocations on different lambdas return different results', async () => {
+              const url = `${routeRoot}/different-lambdas`
+
+              const { invokeFunction: invokeFunctionLambda1 } = await loadSandboxedFunction(ctx)
+              const { invokeFunction: invokeFunctionLambda2 } = await loadSandboxedFunction(ctx)
+
+              const call1 = await invokeFunctionLambda1({ url })
+              expect(call1).not.toBeCacheableResponse()
+
+              const call2 = await invokeFunctionLambda2({ url })
+              expect(call2).toHaveExpectedCachingBehavior(call1, {
+                // default cache is in-memory so we expect lambdas not to share data
+                getDataTimeShouldShouldBeEqual: false,
+                resultWrapperComponentTimeShouldBeEqual: false,
+                pageComponentTimeShouldBeEqual: false,
+              })
+            })
+
+            test<FixtureTestContext>('invalidating tag on one lambda result in invalidating them on all lambdas', async () => {
+              const url = `${routeRoot}/different-lambdas-tag-invalidation`
+
+              const { invokeFunction: invokeFunctionLambda1 } = await loadSandboxedFunction(ctx)
+              const { invokeFunction: invokeFunctionLambda2 } = await loadSandboxedFunction(ctx)
+
+              const call1 = await invokeFunctionLambda1({ url })
+              expect(call1).not.toBeCacheableResponse()
+
+              await invokeFunctionLambda2({ url: `/api/revalidate/${useCacheTagPrefix}/${url}` })
+
+              const call2 = await invokeFunctionLambda1({ url })
+              expect(call2).toHaveExpectedCachingBehavior(call1, {
+                // invalidation done by lambda2 should invalidate lambda1 as well
+                getDataTimeShouldShouldBeEqual: false,
+                resultWrapperComponentTimeShouldBeEqual: false,
+                pageComponentTimeShouldBeEqual: false,
+              })
+            })
+          })
+
+          describe('TTL=5 seconds', () => {
+            const routeRoot = `default/${useCacheLocationPathSegment}/dynamic/ttl-5seconds`
+
+            test<FixtureTestContext>('regenerate after 5 seconds', async () => {
+              const url = `${routeRoot}/same-lambda`
+
+              const { invokeFunction } = await loadSandboxedFunction(ctx)
+
+              const call1 = await invokeFunction({ url })
+              expect(call1).not.toBeCacheableResponse()
+
+              const call2 = await invokeFunction({ url })
+              // making sure that setup is correct first and that caching is enabled
+              expect(call2).toHaveExpectedCachingBehavior(
+                call1,
+                expectedCachingBehaviorWhenUseCacheRegenerates,
+              )
+
+              // wait for cache to expire
+              await new Promise((resolve) => setTimeout(resolve, 5000))
+
+              const call3 = await invokeFunction({ url })
+              expect(call3).toHaveExpectedCachingBehavior(call2, {
+                // cache should expire and fresh content should be generated
+                getDataTimeShouldShouldBeEqual: false,
+                resultWrapperComponentTimeShouldBeEqual: false,
+                pageComponentTimeShouldBeEqual: false,
+              })
+            })
+          })
+        })
+
+        describe('static page (using response cache)', () => {
+          for (const { isPrerendered, isPrerenderedTestLabel, isPrerenderedPathSegment } of [
+            {
+              isPrerendered: true,
+              isPrerenderedTestLabel: 'prerendered',
+              isPrerenderedPathSegment: 'prerendered',
+            },
+            {
+              isPrerendered: false,
+              isPrerenderedTestLabel: 'not prerendered',
+              isPrerenderedPathSegment: 'not-prerendered',
+            },
+          ]) {
+            describe(isPrerenderedTestLabel, () => {
+              describe('page TTL=1 year, use cache TTL=1 year', () => {
+                const routeRoot = `default/${useCacheLocationPathSegment}/static/ttl-1year`
+
+                test<FixtureTestContext>('response cache continue to work and skips use cache handling', async () => {
+                  const url = `${routeRoot}/${isPrerenderedPathSegment}`
+
+                  const { invokeFunction } = await loadSandboxedFunction(ctx)
+
+                  if (isPrerendered) {
+                    const callPrerenderedStale = await invokeFunction({ url })
+                    expect(callPrerenderedStale.headers['cache-status']).toBe(
+                      '"Next.js"; hit; fwd=stale',
+                    )
+                  }
+
+                  const call1 = await invokeFunction({ url })
+                  expect(call1).toBeCacheableResponse()
+                  expect(call1).toHaveResponseCacheTag(`${useCacheTagPrefix}/${url}`)
+
+                  const call2 = await invokeFunction({ url })
+
+                  expect(call2).toHaveExpectedCachingBehavior(call1, {
+                    // response is served from response cache and `use cache` is not even actually used
+                    getDataTimeShouldShouldBeEqual: true,
+                    resultWrapperComponentTimeShouldBeEqual: true,
+                    pageComponentTimeShouldBeEqual: true,
+                  })
+
+                  // test response invalidation
+                  await invokeFunction({
+                    url: `/api/revalidate/${useCacheTagPrefix}/${url}`,
+                  })
+
+                  const call3 = await invokeFunction({ url })
+
+                  expect(call3).toHaveExpectedCachingBehavior(call2, {
+                    // invalidation shot result in everything changing
+                    getDataTimeShouldShouldBeEqual: false,
+                    resultWrapperComponentTimeShouldBeEqual: false,
+                    pageComponentTimeShouldBeEqual: false,
+                  })
+                })
+              })
+
+              describe('page TTL=5 seconds / use cache TTL=10 seconds', () => {
+                const routeRoot = `default/${useCacheLocationPathSegment}/static/ttl-10seconds`
+
+                test<FixtureTestContext>('both response cache and use cache respect their TTLs', async () => {
+                  const url = `${routeRoot}/${isPrerenderedPathSegment}`
+
+                  const { invokeFunction } = await loadSandboxedFunction(ctx)
+
+                  if (isPrerendered) {
+                    const callPrerenderedStale = await invokeFunction({ url })
+                    expect(callPrerenderedStale.headers['cache-status']).toBe(
+                      '"Next.js"; hit; fwd=stale',
+                    )
+                  }
+
+                  const call1 = await invokeFunction({ url })
+                  expect(call1).toBeCacheableResponse()
+                  expect(call1).toHaveResponseCacheTag(`${useCacheTagPrefix}/${url}`)
+
+                  const call2 = await invokeFunction({ url })
+
+                  expect(call2).toHaveExpectedCachingBehavior(call1, {
+                    // response is served from response cache and `use cache` is not even actually used
+                    getDataTimeShouldShouldBeEqual: true,
+                    resultWrapperComponentTimeShouldBeEqual: true,
+                    pageComponentTimeShouldBeEqual: true,
+                  })
+
+                  // wait for use cache to expire
+                  await new Promise((resolve) => setTimeout(resolve, 5000))
+
+                  const call3 = await invokeFunction({ url })
+                  expect(call3).toHaveExpectedCachingBehavior(call2, {
+                    // still stale content on first request after invalidation
+                    getDataTimeShouldShouldBeEqual: true,
+                    resultWrapperComponentTimeShouldBeEqual: true,
+                    pageComponentTimeShouldBeEqual: true,
+                  })
+
+                  const call4 = await invokeFunction({ url })
+                  // fresh response, but use cache should still use cached data
+                  expect(call4).toHaveExpectedCachingBehavior(
+                    call3,
+                    expectedCachingBehaviorWhenUseCacheRegenerates,
+                  )
+                })
+              })
+            })
+          }
+        })
+      })
+    }
+  })
+})

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -2,8 +2,7 @@ import fs from 'node:fs'
 import { afterEach } from 'vitest'
 import { type FixtureTestContext } from './utils/contexts'
 
-// cleanup after each test as a fallback if someone forgot to call it
-afterEach<FixtureTestContext>(async ({ cleanup }) => {
+export async function afterTestCleanup({ cleanup }: FixtureTestContext) {
   if ('reset' in fs) {
     ;(fs as any).reset()
   }
@@ -11,4 +10,9 @@ afterEach<FixtureTestContext>(async ({ cleanup }) => {
   const jobs = (cleanup ?? []).map((job) => job())
 
   await Promise.all(jobs)
+}
+
+// cleanup after each test as a fallback if someone forgot to call it
+afterEach<FixtureTestContext>(async (ctx) => {
+  await afterTestCleanup(ctx)
 })


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

This is work in progress to support upcoming [`'use cache'` directive](https://nextjs.org/docs/app/api-reference/directives/use-cache)

Notes:
The primary need for custom Netlify cache handler implementation (the new one, that is used by `'use cache'` directive) is that default implementation is in-memory only. While it seems like at least `default` handler for `use cache` doesn't need entries to be actually persisted - it still need to support tags (see [`cacheTag`](https://nextjs.org/docs/app/api-reference/functions/cacheTag)) properly and in serverless environment it means that we can't use in-memory only tag manifest like the default implementation does and will need to check with some persisted source of truth.

Review notes:
This PR contains also changes from following refactor PRs that it depends on.
- https://github.com/opennextjs/opennextjs-netlify/pull/2871
- https://github.com/opennextjs/opennextjs-netlify/pull/2872

To check just "use cache" specific changes without polluting diff with refactors use this [compare view](https://github.com/opennextjs/opennextjs-netlify/compare/tmp-just-use-cache-base...michalpiechowiak/frb-1405-next15-use-cache-not-persisted?w=1)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Primarily integration tests are being added for various `use cache` scenarios:
 - Is response cacheable on cdn? (static/dynamic page)
 - What `use cache` is used on (data fetching function, non-page react component, page react component, whole page module)

And test check behavior when executing against same serverless function instance, different serverless function instances (default cache is in-memory only, so to test behaviors it forces use of integration tests as you can't ensure hitting same or different serverless function in e2e), checking behaviors after tag invalidation (also depending on wether same serverless instance is used or not and that it should work the same in both cases because tags are shared, while cache entries themselves are not) and finally checking that expiry behavior works.

Tests failing on their own in https://github.com/opennextjs/opennextjs-netlify/actions/runs/14674525410/job/41267496397 (comment about most of tests passing - lot of test cases there do NOT test primary difference between Next.js's default cache handler and Netlify's implementation - only test related to revalidating tags on different lambda that is checked later - this is somewhat intentional because the whole cache handler is implemented here and doesn't reuse Next.js code - this is intentional to make sure any potentially future changes to default cache handler don't break any assumptions - and because we don't actually share code I added test cases just for overall cache handler behavior to make sure it works as expected)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1405/[next15]-use-cache-not-persisted
