### PR TITLE
test: allow cache-status to be either comma or line separated

### DIFF
--- a/tests/e2e/dynamic-cms.test.ts
+++ b/tests/e2e/dynamic-cms.test.ts
@@ -57,8 +57,8 @@ test.describe('Dynamic CMS', () => {
 
         expect(response1?.status()).toEqual(404)
         expect(headers1['cache-control']).toEqual('public,max-age=0,must-revalidate')
-        expect(headers1['cache-status']).toEqual(
-          '"Next.js"; fwd=miss, "Netlify Durable"; fwd=uri-miss; stored, "Netlify Edge"; fwd=miss',
+        expect(headers1['cache-status']).toMatch(
+          /"Next.js"; fwd=miss\s*(,|\n)\s*"Netlify Durable"; fwd=uri-miss; stored\s*(, |\n)\s*"Netlify Edge"; fwd=miss/,
         )
         expect(headers1['netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers1['netlify-cdn-cache-control']).toMatch(
@@ -77,7 +77,7 @@ test.describe('Dynamic CMS', () => {
         expect(response2?.status()).toEqual(200)
         expect(headers2['cache-control']).toEqual('public,max-age=0,must-revalidate')
         expect(headers2['cache-status']).toMatch(
-          /"Next.js"; hit, "Netlify Durable"; fwd=stale; ttl=[0-9]+; stored, "Netlify Edge"; fwd=(stale|miss)/,
+          /"Next.js"; hit\s*(,|\n)\s*"Netlify Durable"; fwd=stale; ttl=[0-9]+; stored\s*(,|\n)\s*"Netlify Edge"; fwd=(stale|miss)/,
         )
         expect(headers2['netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers2['netlify-cdn-cache-control']).toMatch(
@@ -96,7 +96,7 @@ test.describe('Dynamic CMS', () => {
         expect(response3?.status()).toEqual(404)
         expect(headers3['cache-control']).toEqual('public,max-age=0,must-revalidate')
         expect(headers3['cache-status']).toMatch(
-          /"Next.js"; fwd=miss, "Netlify Durable"; fwd=stale; ttl=[0-9]+; stored, "Netlify Edge"; fwd=(stale|miss)/,
+          /"Next.js"; fwd=miss\s*(,|\n)\s*"Netlify Durable"; fwd=stale; ttl=[0-9]+; stored\s*(,|\n)\s*"Netlify Edge"; fwd=(stale|miss)/,
         )
         expect(headers3['netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers3['netlify-cdn-cache-control']).toMatch(


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

See  https://github.com/opennextjs/opennextjs-netlify/actions/runs/14588003174/job/40916950224

this loosens up comparison to allow either `,` or line break separation + some optional whitespaces in case things change in the future to not be so rigid, but still assert important bits

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Adjusting existing test assertions

## Relevant links (GitHub issues, etc.) or a picture of cute animal

https://linear.app/netlify/issue/FRB-1757/next-runtime-e2e-assertions-failing
