### PR TITLE
fix: add a fallback for loadManifest import path

### DIFF
--- a/src/run/handlers/cache.cts
+++ b/src/run/handlers/cache.cts
@@ -176,7 +176,13 @@ export class NetlifyCacheHandler implements CacheHandlerForMultipleVersions {
         typeof cacheControl !== 'undefined')
     ) {
       try {
-        const { loadManifest } = await import('next/dist/server/load-manifest.js')
+        let loadManifest
+        try {
+          // Starting in 15.4.0-canary.10 loadManifest was relocated (https://github.com/vercel/next.js/pull/78358)
+          ({ loadManifest } = await import('next/dist/server/load-manifest.external.js'))
+        } catch {
+          ({ loadManifest } = await import('next/dist/server/load-manifest.js'))
+        }
         const prerenderManifest = loadManifest(
           join(this.options.serverDistDir, '..', 'prerender-manifest.json'),
         ) as PrerenderManifest

--- a/src/run/handlers/cache.cts
+++ b/src/run/handlers/cache.cts
@@ -178,10 +178,12 @@ export class NetlifyCacheHandler implements CacheHandlerForMultipleVersions {
       try {
         let loadManifest
         try {
-          // Starting in 15.4.0-canary.10 loadManifest was relocated (https://github.com/vercel/next.js/pull/78358)
-          ({ loadManifest } = await import('next/dist/server/load-manifest.external.js'))
+          // @ts-expect-error Starting in 15.4.0-canary.10 loadManifest was relocated (https://github.com/vercel/next.js/pull/78358)
+          // eslint-disable-next-line @typescript-eslint/no-extra-semi, n/no-missing-import, import/no-unresolved
+          ;({ loadManifest } = await import('next/dist/server/load-manifest.external.js'))
         } catch {
-          ({ loadManifest } = await import('next/dist/server/load-manifest.js'))
+          // eslint-disable-next-line @typescript-eslint/no-extra-semi
+          ;({ loadManifest } = await import('next/dist/server/load-manifest.js'))
         }
         const prerenderManifest = loadManifest(
           join(this.options.serverDistDir, '..', 'prerender-manifest.json'),


### PR DESCRIPTION
## Description

Resolves failures in next@canary integration tests

## Tests

Ran the code changes with `test all versions` tag to ensure failing canary integration tests are now resolved

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes FRB-1770
