### PR TITLE
chore: vendor deno modules used in integration test helpers

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -151,6 +151,8 @@ jobs:
         run: npm ci
       - name: 'Build'
         run: npm run build
+      - name: 'Vendor deno helpers for integration tests'
+        run: node tools/vendor-deno-tools.js
       - name: Resolve Next.js version
         id: resolve-next-version
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 dist/
 .next
 edge-runtime/vendor
+# deno.json is ephemeral and generated for the purpose of vendoring remote modules in CI
+tools/deno/deno.json
+tools/deno/vendor
 
 # Local Netlify folder
 .netlify

--- a/tools/build-helpers.js
+++ b/tools/build-helpers.js
@@ -1,0 +1,70 @@
+import { createWriteStream } from 'node:fs'
+import { rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { Readable } from 'stream'
+import { finished } from 'stream/promises'
+
+import { execaCommand } from 'execa'
+
+/**
+ * @param {Object} options
+ * @param {string} options.vendorSource Path to the file to vendor
+ * @param {string} options.cwd Directory to run the command in
+ * @param {string[]} [options.wasmFilesToDownload] List of wasm files to download
+ * @param {boolean} [options.initEmptyDenoJson] If true, will create an empty deno.json file
+ */
+export async function vendorDeno({
+  vendorSource,
+  cwd,
+  wasmFilesToDownload = [],
+  initEmptyDenoJson = false,
+}) {
+  try {
+    await execaCommand('deno --version')
+  } catch {
+    throw new Error('Could not check the version of Deno. Is it installed on your system?')
+  }
+
+  const vendorDest = join(cwd, 'vendor')
+
+  console.log(`🧹 Deleting '${vendorDest}'...`)
+
+  await rm(vendorDest, { force: true, recursive: true })
+
+  if (initEmptyDenoJson) {
+    const denoJsonPath = join(cwd, 'deno.json')
+    console.log(`🧹 Generating clean '${denoJsonPath}`)
+    await writeFile(denoJsonPath, '{}')
+  }
+
+  console.log(`📦 Vendoring Deno modules for '${vendorSource}' into '${vendorDest}'...`)
+  // --output=${vendorDest}
+  await execaCommand(`deno vendor ${vendorSource}  --force`, {
+    cwd,
+  })
+
+  if (wasmFilesToDownload.length !== 0) {
+    console.log(`⬇️ Downloading wasm files...`)
+
+    // deno vendor doesn't work well with wasm files
+    // see https://github.com/denoland/deno/issues/14123
+    // to workaround this we copy the wasm files manually
+    // (note Deno 2 allows to vendor wasm files, but it also require modules to import them and not fetch and instantiate them
+    // se being able to drop downloading is dependent on implementation of wasm handling in external modules as well)
+    await Promise.all(
+      wasmFilesToDownload.map(async (urlString) => {
+        const url = new URL(urlString)
+
+        const destination = join(vendorDest, url.hostname, url.pathname)
+
+        const res = await fetch(url)
+        if (!res.ok)
+          throw new Error(`Failed to fetch .wasm file to vendor. Response status: ${res.status}`)
+        const fileStream = createWriteStream(destination, { flags: 'wx' })
+        await finished(Readable.fromWeb(res.body).pipe(fileStream))
+      }),
+    )
+  }
+
+  console.log(`✅ Vendored Deno modules for '${vendorSource}' into '${vendorDest}'`)
+}

--- a/tools/vendor-deno-tools.js
+++ b/tools/vendor-deno-tools.js
@@ -1,0 +1,13 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { vendorDeno } from './build-helpers.js'
+
+const denoToolsDirectory = join(dirname(fileURLToPath(import.meta.url)), 'deno')
+
+await vendorDeno({
+  vendorSource: join(denoToolsDirectory, 'eszip.ts'),
+  cwd: denoToolsDirectory,
+  wasmFilesToDownload: ['https://deno.land/x/eszip@v0.55.4/eszip_wasm_bg.wasm'],
+  initEmptyDenoJson: true,
+})


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Seems like added test in https://github.com/opennextjs/opennextjs-netlify/pull/2862 introduces flakiness when setup up fixture in integration tests. I don't think the test itself is the cause of it, but rather the fact that Vitest run few parallel workers all trying to bundle edge functions at the same time and to do that Deno does download eszip wasm file to same cache location in multiple processes around the same time sometimes causing corruption (and added test is just unfortunate to be likely to hit this problem). This adds a step in CI to vendor modules and wasm files used by eszip helper we use to handle edge functions in integration tests which seems to avoid the problem in my tests ( https://github.com/opennextjs/opennextjs-netlify/actions/runs/14751501851?pr=2882 - do note that there are some failing tests there, but those seems like they are caused by something in newest next.js canary and are not related to this change).

This moves deno modules vendoring we already have for package build into helper module which is used by both package build as well as being used for eszip helper in CI 

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
