### PR TITLE
chore: match deno version to builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - name: Extract tag and version
         id: extract
         run: |-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - name: Build
         run: npm run build
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - name: 'Install dependencies'
         run: npm ci
       - name: 'Prepare Netlify CLI'
@@ -146,7 +146,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/edge-bundler/blob/e55f825bd985d3c92e21d1b765d71e70d5628fba/node/bridge.ts#L17
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - name: 'Install dependencies'
         run: npm ci
       - name: 'Build'
@@ -211,7 +211,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - name: 'Install dependencies'
         run: npm ci
       - name: 'Build'

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -24,7 +24,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
       - run: npm ci
 
       - name: Package size report

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -162,7 +162,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/build/blob/main/packages/edge-bundler/node/bridge.ts#L20
-          deno-version: v1.44.4
+          deno-version: v1.46.3
 
       - name: install runtime
         run: npm install --ignore-scripts


### PR DESCRIPTION
## Description

Builds currently use `deno@1.46.3` so these changes match us to that version
https://github.com/netlify/buildbot/blob/766d2c1ac7b7596f18b546cb6bf13962d157b033/build-image/noble/Dockerfile#L412