### PR TITLE
test: update assertions after some react canary changes

### DIFF
--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -93,7 +93,7 @@ test<FixtureTestContext>('linked static resources are placed in correct place in
     ...Array.from(document('script[src]')).map((elem) => {
       return elem.attribs.src
     }),
-    ...Array.from(document('link[href]')).map((elem) => {
+    ...Array.from(document('link[href]:not([blocking="render"])')).map((elem) => {
       return elem.attribs.href
     }),
     ...Array.from(document('img[src]')).map((elem) => {
@@ -143,7 +143,7 @@ test<FixtureTestContext>('linked static resources are placed in correct place in
     ...Array.from(document('script[src]')).map((elem) => {
       return elem.attribs.src
     }),
-    ...Array.from(document('link[href]')).map((elem) => {
+    ...Array.from(document('link[href]:not([blocking="render"])')).map((elem) => {
       return elem.attribs.href
     }),
     ...Array.from(document('img[src]')).map((elem) => {

--- a/tests/integration/static.test.ts
+++ b/tests/integration/static.test.ts
@@ -93,7 +93,7 @@ test<FixtureTestContext>('linked static resources are placed in correct place in
     ...Array.from(document('script[src]')).map((elem) => {
       return elem.attribs.src
     }),
-    ...Array.from(document('link[href]:not([blocking="render"])')).map((elem) => {
+    ...Array.from(document('link[href]:not([rel="expect"])')).map((elem) => {
       return elem.attribs.href
     }),
     ...Array.from(document('img[src]')).map((elem) => {
@@ -143,7 +143,7 @@ test<FixtureTestContext>('linked static resources are placed in correct place in
     ...Array.from(document('script[src]')).map((elem) => {
       return elem.attribs.src
     }),
-    ...Array.from(document('link[href]:not([blocking="render"])')).map((elem) => {
+    ...Array.from(document('link[href]:not([rel="expect"])')).map((elem) => {
       return elem.attribs.href
     }),
     ...Array.from(document('img[src]')).map((elem) => {


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Ref: https://github.com/ampproject/amphtml/issues/40279 / https://github.com/vercel/next.js/pull/78640/files#diff-42717fb2172c81da9ea4c84d272fae170a0f3f09a2b9e999b18fce7426551db9R10-R21

Seems like `<link rel="expect" href="#«R»" blocking="render">` is being added now with `next@canary` which is tripping up some of our integration tests that collect links and ensures linked resources do exist - this just removes those particular `<link>`s from being collected in our test

## Tests

Adjusted 

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes https://linear.app/netlify/issue/FRB-1783/integration-test-for-static-resource-failing-with-1540-canary15
