### PR TITLE
ci: exclude windows runs when testing older versions of next.js

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -114,13 +114,18 @@ jobs:
 
   test:
     needs: setup
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
         os: [ubuntu-latest, windows-latest]
         version: ${{ fromJson(needs.setup.outputs.matrix) }}
+        exclude:
+          - os: windows-latest
+            version: '13.5.1'
+          - os: windows-latest
+            version: '14.2.15'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: 'Install Node'


### PR DESCRIPTION
## Description

When running tests against all versions, skip windows segments testing against v13 and v14
Example run: https://github.com/opennextjs/opennextjs-netlify/actions/runs/14850399526/job/41693090360
