### PR TITLE
ci: remove `--timings` flag for Next.js repo e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -198,7 +198,7 @@ jobs:
           NODE_ENV: production
           NEXT_EXTERNAL_TESTS_FILTERS: ${{ steps.test-filters.outputs.filters }}
           NEXT_TEST_SKIP_RETRY_MANIFEST: ${{ steps.test-filters.outputs.skip-retry }}
-        run: node run-tests.js -g ${{ matrix.group }}/${{ needs.setup.outputs.total }} -c ${TEST_CONCURRENCY} --type e2e --timings
+        run: node run-tests.js -g ${{ matrix.group }}/${{ needs.setup.outputs.total }} -c ${TEST_CONCURRENCY} --type e2e
         working-directory: ${{ env.next-path }}
 
       - name: Upload Test Results


### PR DESCRIPTION
## Description

This doesn't seem to provide any value for us. It just adds some test run time and instability to our suite, since this ends up attempting to read a `test-timings.json` file from disk (fails every time) and then makes a request to fetch timings data from a private Vercel endpoint, which sometimes fails with a 403 for some reason.

### Documentation

N/A

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

It was added here without explanation: https://github.com/netlify/next-runtime-minimal/pull/334/commits/7ea73a2c7c6be6a898bdc6174e09a8198848a1cb