### PR TITLE
chore: remove netlify-cli deploy `--build` flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ following:
    node_module from the registry)
 5. Creating a `netlify.toml` inside the temp directory of the fixture and adding the runtime as a
    plugin.
-6. Running `netlify deploy --build` invoking the runtime. This will use the
+6. Running `netlify deploy` invoking the runtime during the build step. This will use the
    [next-runtime-testing](https://app.netlify.com/sites/next-runtime-testing/overview) as site to
    deploy to.
 7. Using the `deployId` and `url` of the deployed site to run some

--- a/tests/netlify-deploy.ts
+++ b/tests/netlify-deploy.ts
@@ -133,7 +133,7 @@ export class NextDeployInstance extends NextInstance {
 
     const deployRes = await execa(
       'npx',
-      ['netlify', 'deploy', '--build', '--message', deployTitle ?? '', '--alias', deployAlias],
+      ['netlify', 'deploy', '--message', deployTitle ?? '', '--alias', deployAlias],
       {
         cwd: this.testDir,
         reject: false,

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -269,7 +269,7 @@ async function deploySite(
   console.log(`🚀 Building and deploying site...`)
 
   const outputFile = 'deploy-output.txt'
-  let cmd = `npx netlify deploy --build --site ${siteId} --alias ${NETLIFY_DEPLOY_ALIAS}`
+  let cmd = `npx netlify deploy --site ${siteId} --alias ${NETLIFY_DEPLOY_ALIAS}`
 
   if (packagePath) {
     cmd += ` --filter ${packagePath}`


### PR DESCRIPTION
## Description

It builds by default since 21.0.0.

This avoids printing a warning.