### PR TITLE
chore: add e2e report skip entry for renamed `basepath.test.ts`

### DIFF
--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -199,8 +199,18 @@
       ]
     },
     {
+      "//": "This was the test file name before v15.3.0-canary.27 / v15.3.0",
       "file": "test/e2e/basepath.test.ts",
-      "reason": "Hard-coded Vercel error message",
+      "reason": "Hard-coded expectation of Vercel's default 404 page",
+      "tests": [
+        "basePath should not update URL for a 404",
+        "basePath should handle 404 urls that start with basePath",
+        "basePath should show 404 for page not under the /docs prefix"
+      ]
+    },
+    {
+      "file": "test/e2e/basepath/basepath.test.ts",
+      "reason": "Hard-coded expectation of Vercel's default 404 page",
       "tests": [
         "basePath should not update URL for a 404",
         "basePath should handle 404 urls that start with basePath",


### PR DESCRIPTION
## Description

This test suite file was moved in https://github.com/vercel/next.js/pull/77630.

This results in it showing up as failed in new reports: https://682e414a03ba12f55c5f417b--runtime-e2e-report.netlify.app/.

Example run here:
https://github.com/opennextjs/opennextjs-netlify/actions/runs/15163298543#summary-42664185436.

I also clarified the `reason` field.

We could do something gross to expect the Netlify default 404 page or configure a custom 404 page that mimics Vercel's... but I don't think it's worth it.

### Documentation

N/A

## Tests

N/A