### PR TITLE
chore: fix team name in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/ecosystem-pod-frameworks
+* @opennextjs/netlify-frameworks-and-build


### PR DESCRIPTION
We missed this when moving to this org. This is why PRs don't get the reviewer auto-assigned!