### PR TITLE
feat: allow next middleware to use edge cache

### DIFF
--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -172,7 +172,10 @@ const buildHandlerDefinition = (
   const functionName = name.endsWith('middleware')
     ? 'Next.js Middleware Handler'
     : `Next.js Edge Handler: ${page}`
-  const cache = name.endsWith('middleware') ? undefined : ('manual' as const)
+  const cache =
+    !process.env.NEXT_MIDDLEWARE_CACHE && name.endsWith('middleware')
+      ? undefined
+      : ('manual' as const)
   const generator = `${ctx.pluginName}@${ctx.pluginVersion}`
 
   return augmentMatchers(matchers, ctx).map((matcher) => ({

--- a/tests/fixtures/middleware-edge-cache/app/layout.js
+++ b/tests/fixtures/middleware-edge-cache/app/layout.js
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: 'Simple Next App',
+  description: 'Description for Simple Next App',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/tests/fixtures/middleware-edge-cache/app/page.js
+++ b/tests/fixtures/middleware-edge-cache/app/page.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+    </main>
+  )
+}

--- a/tests/fixtures/middleware-edge-cache/app/test/cached/page.js
+++ b/tests/fixtures/middleware-edge-cache/app/test/cached/page.js
@@ -1,0 +1,7 @@
+export default function EdgeCached() {
+  return (
+    <main>
+      <h1>If middleware works, we shoudn't get here</h1>
+    </main>
+  )
+}

--- a/tests/fixtures/middleware-edge-cache/app/test/next/page.js
+++ b/tests/fixtures/middleware-edge-cache/app/test/next/page.js
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+export default function Page() {
+  const headersList = headers()
+  const message = headersList.get('x-hello-from-middleware-req')
+
+  return (
+    <main>
+      <h1>Message from middleware: {message}</h1>
+    </main>
+  )
+}

--- a/tests/fixtures/middleware-edge-cache/app/test/uncached/page.js
+++ b/tests/fixtures/middleware-edge-cache/app/test/uncached/page.js
@@ -1,0 +1,7 @@
+export default function EdgeUncached() {
+  return (
+    <main>
+      <h1>If middleware works, we shoudn't get here</h1>
+    </main>
+  )
+}

--- a/tests/fixtures/middleware-edge-cache/middleware.ts
+++ b/tests/fixtures/middleware-edge-cache/middleware.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const response = getResponse(request)
+
+  response.headers.append('Deno' in globalThis ? 'x-deno' : 'x-node', Date.now().toString())
+  response.headers.set('x-hello-from-middleware-res', 'hello')
+
+  return response
+}
+
+const getResponse = (request: NextRequest) => {
+  const requestHeaders = new Headers(request.headers)
+
+  requestHeaders.set('x-hello-from-middleware-req', 'hello')
+
+  if (request.nextUrl.pathname === '/test/cached') {
+    return NextResponse.next({
+      request: {
+        headers: new Headers({
+          ...requestHeaders,
+          'netlify-cdn-cache-control': 's-maxage=31536000, durable',
+        }),
+      },
+    })
+  }
+
+  if (request.nextUrl.pathname === '/test/uncached') {
+    return NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    })
+  }
+
+  return NextResponse.json({ error: 'Error' }, { status: 500 })
+}

--- a/tests/fixtures/middleware-edge-cache/next.config.js
+++ b/tests/fixtures/middleware-edge-cache/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+}
+
+module.exports = nextConfig

--- a/tests/fixtures/middleware-edge-cache/package.json
+++ b/tests/fixtures/middleware-edge-cache/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "middleware-edge-cache",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "next build",
+    "dev": "next dev",
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}


### PR DESCRIPTION
## Description

Allow the Next.js middleware to use Edge caching as a configurable flag.

This is a beneficial feature for the Next.js middleware, and I cannot think of any reason why the Next.js Edge Function can't support it after patching and testing it in a real project with zero side effects.

In addition, sharing code between Next.js and vanilla Edge Functions can be very tricky, while having everything under one roof with caching capability simplifies the entire process. 

### Documentation

https://docs.netlify.com/edge-functions/optional-configuration/#response-caching

## Tests

I have included a new fixture and integration test that toggles Edge caching on.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

n/a