### PR TITLE
test: print cli output when timing out

### DIFF
--- a/tests/netlify-deploy.ts
+++ b/tests/netlify-deploy.ts
@@ -154,6 +154,8 @@ export class NextDeployInstance extends NextInstance {
     const deployRes = await deployResPromise
 
     if (deployRes.exitCode !== 0) {
+      // clear deploy output to avoid printing it again in destroy()
+      this._deployOutput = ''
       throw new Error(
         `Failed to deploy project (${deployRes.exitCode}) ${deployRes.stdout} ${deployRes.stderr} `,
       )


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

To aid with debugging vercel/next tests that are just timing out without any meaningful output this captures the output and will print it out if `destroy()` is called before deploy finished to figure out if something is just slow or we are sometimes hanging on something.

See example https://github.com/opennextjs/opennextjs-netlify/actions/runs/15591799921/job/43913715730#step:20:82 (from test run on tmp commit that was intentionally timing out)