### PR TITLE
ci: use windows-2025 runner

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,12 +118,12 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
         version: ${{ fromJson(needs.setup.outputs.matrix) }}
         exclude:
-          - os: windows-latest
+          - os: windows-2025
             version: '13.5.1'
-          - os: windows-latest
+          - os: windows-2025
             version: '14.2.15'
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Description

Changes the windows runner to use the latest version available
Appears to bring the duration of tests running on the windows images back to a normal range

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
