### PR TITLE
test: use a unique deploy alias per test group to avoid deploy concurrency issues

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -198,6 +198,10 @@ jobs:
           NODE_ENV: production
           NEXT_EXTERNAL_TESTS_FILTERS: ${{ steps.test-filters.outputs.filters }}
           NEXT_TEST_SKIP_RETRY_MANIFEST: ${{ steps.test-filters.outputs.skip-retry }}
+          # Use a unique alias per test matrix group and shard. Otherwise, a deploy within
+          # one job may wait for deploys in other jobs (only one deploy may be in progress for
+          # a given alias at a time), resulting in cascading timeouts.
+          DEPLOY_ALIAS: vercel-next-e2e-${{ matrix.version_spec.selector }}-${{ matrix.group }}
         run: node run-tests.js -g ${{ matrix.group }}/${{ needs.setup.outputs.total }} -c ${TEST_CONCURRENCY} --type e2e
         working-directory: ${{ env.next-path }}
 

--- a/tests/netlify-deploy.ts
+++ b/tests/netlify-deploy.ts
@@ -133,7 +133,7 @@ export class NextDeployInstance extends NextInstance {
     const deployTitle = process.env.GITHUB_SHA
       ? `${testName} - ${process.env.GITHUB_SHA}`
       : testName
-    const deployAlias = 'vercel-next-e2e'
+    const deployAlias = process.env.DEPLOY_ALIAS ?? 'vercel-next-e2e'
 
     const deployResPromise = execa(
       'npx',


### PR DESCRIPTION
## Description

See inline comment

### Documentation

See https://docs.netlify.com/cli/get-started/#draft-deploys

## Tests

Set `run-e2e-tests` label on this PR to run e2e tests to verify this change

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Part of FRB-1896