### PR TITLE
feat: add css files to server bundle for optimizeCss feature to work

### DIFF
--- a/src/build/content/server.ts
+++ b/src/build/content/server.ts
@@ -99,7 +99,14 @@ export const copyNextServerCode = async (ctx: PluginContext): Promise<void> => {
     const destDir = join(ctx.serverHandlerDir, nextFolder)
 
     const paths = await glob(
-      [`*`, `server/*`, `server/chunks/*`, `server/edge-chunks/*`, `server/+(app|pages)/**/*.js`],
+      [
+        `*`,
+        `server/*`,
+        `server/chunks/*`,
+        `server/edge-chunks/*`,
+        `server/+(app|pages)/**/*.js`,
+        `static/css/*`,
+      ],
       {
         cwd: srcDir,
         extglob: true,


### PR DESCRIPTION
## Description

The inlining of Critical CSS with the optimizeCss feature doesn't work when using Next.js 15.3.3 (Page Router) and @netlify/plugin-nextjs 5.11.2.

The optimizeCss feature relies on the CSS files being present in the server-function bundle. During page rendering (e.g., during ISR or revalidation), a server function using the Critters library attempts to locate the CSS files used on the page and inline them in the HTML. Without these files in the server-function bundle, the inlining process fails.

These changes make the bundling process include `.next/static/css` files in the server-function bundle.

Detailed information is in the attached issue below.

### Documentation

This is an internal change that should not require documentation.

## Tests

Code coverage did not change. That should not require tests changes.

## GitHub issue

https://github.com/opennextjs/opennextjs-netlify/issues/2963
