### PR TITLE
test: add handling for skipped tests moved out of `e2e/basepath/basepath.test.ts`

### DIFF
--- a/tests/e2e-skip-retry.json
+++ b/tests/e2e-skip-retry.json
@@ -29,6 +29,8 @@
   "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts",
   "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts",
   "test/e2e/basepath.test.ts",
+  "test/e2e/basepath/basepath.test.ts",
+  "test/e2e/basepath/error-pages.test.ts",
   "test/e2e/getserversideprops/test/index.test.ts",
   "test/e2e/middleware-general/test/index.test.ts",
   "test/e2e/module-layer/index.test.ts",

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -209,11 +209,20 @@
       ]
     },
     {
+      "//": "These tests were in this file before v15.4.0-canary.32 extracted them to a new file",
       "file": "test/e2e/basepath/basepath.test.ts",
       "reason": "Hard-coded expectation of Vercel's default 404 page",
       "tests": [
         "basePath should not update URL for a 404",
         "basePath should handle 404 urls that start with basePath",
+        "basePath should show 404 for page not under the /docs prefix"
+      ]
+    },
+    {
+      "file": "test/e2e/basepath/error-pages.test.ts",
+      "reason": "Hard-coded expectation of Vercel's default 404 page",
+      "tests": [
+        "basePath should not update URL for a 404",
         "basePath should show 404 for page not under the /docs prefix"
       ]
     },


### PR DESCRIPTION
## Description

See https://github.com/vercel/next.js/commit/3f9f403a048f1f3b1419d92f70245d4e8c77ac27.

Some tests were split out of the test file we were referencing into new test files. This adds handling for the new file name. We must keep the previous config to support running tests against older versions.

See example "unknown failure": https://github.com/opennextjs/opennextjs-netlify/actions/runs/15643078756.

### Documentation

N/A

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

N/A