### PR TITLE
fix: handle shared-cache-controls rename

### DIFF
--- a/tests/fixtures/page-router-base-path-i18n/pages/fallback-true/[slug].js
+++ b/tests/fixtures/page-router-base-path-i18n/pages/fallback-true/[slug].js
@@ -27,7 +27,8 @@ export async function getStaticProps({ params }) {
   }
 }
 
-export const getStaticPaths = () => {
+/** @type {import('next').GetStaticPaths} */
+export const getStaticPaths = ({ locales }) => {
   return {
     paths: [
       {
@@ -35,7 +36,7 @@ export const getStaticPaths = () => {
           slug: 'prerendered',
         },
       },
-    ],
+    ].flatMap((pathDescription) => locales.map((locale) => ({ ...pathDescription, locale }))),
     fallback: true,
   }
 }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

There was some changes in `next@canary` but break some of our handling. This address one of them. Remaining failing tests are results of regression in `next@canary` (see https://github.com/vercel/next.js/issues/80838 ) which hopefully be addressed in Next.js.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
