### PR TITLE
test: adjust assertions to work with validateRSCRequestHeaders enabled

### DIFF
--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -373,7 +373,11 @@ test.describe('RSC cache poisoning', () => {
   test('Middleware rewrite', async ({ page, middleware }) => {
     const prefetchResponsePromise = new Promise<Response>((resolve) => {
       page.on('response', (response) => {
-        if (response.url().includes('/test/rewrite-to-cached-page')) {
+        if (
+          (response.url().includes('/test/rewrite-to-cached-page') ||
+            response.url().includes('/caching-rewrite-target')) &&
+          response.status() === 200
+        ) {
           resolve(response)
         }
       })
@@ -400,7 +404,7 @@ test.describe('RSC cache poisoning', () => {
   test('Middleware redirect', async ({ page, middleware }) => {
     const prefetchResponsePromise = new Promise<Response>((resolve) => {
       page.on('response', (response) => {
-        if (response.url().includes('/caching-redirect-target')) {
+        if (response.url().includes('/caching-redirect-target') && response.status() === 200) {
           resolve(response)
         }
       })


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

`next@canary` now are automatically opting into `validateRSCRequestHeaders` (note currently it seems like this is enabled in canary only - https://github.com/vercel/next.js/pull/80954 so possibly won't be applied to future stable releases and will remain canary-only)

This does result in additional 307 redirects for middleware redirects ... and rewrites (!). 

In this PR I adjusted our currently failing tests for cache poisoning to work with that additional redirect