### PR TITLE
test: add next version constraint for turbopack fixture and test

### DIFF
--- a/tests/fixtures/hello-world-turbopack/package.json
+++ b/tests/fixtures/hello-world-turbopack/package.json
@@ -11,5 +11,10 @@
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "test": {
+    "dependencies": {
+      "next": ">=15.3.0-canary.43"
+    }
   }
 }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Test and fixture added in https://github.com/opennextjs/opennextjs-netlify/pull/2987 only make sense with next versions that do actually support `--turbopack` builds. Right now integration tests for v13.5.1 and v14 are failing because of unknown to those versions CLI option failing the build and this PR is making sure used next version support turbobpack toggle