### PR TITLE
chore: pin edge bootstrap

### DIFF
--- a/tests/utils/fixture.ts
+++ b/tests/utils/fixture.ts
@@ -32,7 +32,8 @@ import { BLOB_TOKEN } from './constants.mjs'
 import { type FixtureTestContext } from './contexts.js'
 import { setNextVersionInFixture } from './next-version-helpers.mjs'
 
-const bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
+const bootstrapURL =
+  'https://6877afcf20679a00086bab1c--edge.netlify.com/bootstrap/index-combined.ts'
 const actualCwd = await vi.importActual<typeof import('process')>('process').then((p) => p.cwd())
 const eszipHelper = join(actualCwd, 'tools/deno/eszip.ts')
 


### PR DESCRIPTION
This is to unblock our integration tests that currently fail whenever edge function invocation is involved (for example https://github.com/opennextjs/opennextjs-netlify/actions/runs/16641424943/job/47092320556 )