### PR TITLE
chore: set outputFileTracingRoot for fixtures

### DIFF
--- a/tests/fixtures/advanced-api-routes/next.config.js
+++ b/tests/fixtures/advanced-api-routes/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/after/next.config.js
+++ b/tests/fixtures/after/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/base-path/next.config.js
+++ b/tests/fixtures/base-path/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/cli-before-regional-blobs-support/next.config.js
+++ b/tests/fixtures/cli-before-regional-blobs-support/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/dist-dir/next.config.js
+++ b/tests/fixtures/dist-dir/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/dynamic-cms/next.config.js
+++ b/tests/fixtures/dynamic-cms/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
     defaultLocale: 'en',
   },
   generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/hello-world-turbopack/next.config.ts
+++ b/tests/fixtures/hello-world-turbopack/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-conditions/next.config.js
+++ b/tests/fixtures/middleware-conditions/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-i18n-excluded-paths/next.config.js
+++ b/tests/fixtures/middleware-i18n-excluded-paths/next.config.js
@@ -7,4 +7,5 @@ module.exports = {
     locales: ['en', 'fr'],
     defaultLocale: 'en',
   },
+  outputFileTracingRoot: __dirname,
 }

--- a/tests/fixtures/middleware-i18n-skip-normalize/next.config.js
+++ b/tests/fixtures/middleware-i18n-skip-normalize/next.config.js
@@ -21,4 +21,5 @@ module.exports = {
       },
     ]
   },
+  outputFileTracingRoot: __dirname,
 }

--- a/tests/fixtures/middleware-i18n/next.config.js
+++ b/tests/fixtures/middleware-i18n/next.config.js
@@ -20,4 +20,5 @@ module.exports = {
       },
     ]
   },
+  outputFileTracingRoot: __dirname,
 }

--- a/tests/fixtures/middleware-og/next.config.js
+++ b/tests/fixtures/middleware-og/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-pages/next.config.js
+++ b/tests/fixtures/middleware-pages/next.config.js
@@ -58,4 +58,5 @@ module.exports = {
       },
     ]
   },
+  outputFileTracingRoot: __dirname,
 }

--- a/tests/fixtures/middleware-src/next.config.js
+++ b/tests/fixtures/middleware-src/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-static-asset-matcher/next.config.js
+++ b/tests/fixtures/middleware-static-asset-matcher/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-subrequest-vuln/next.config.js
+++ b/tests/fixtures/middleware-subrequest-vuln/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware-trailing-slash/next.config.js
+++ b/tests/fixtures/middleware-trailing-slash/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/middleware/next.config.js
+++ b/tests/fixtures/middleware/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
 
     return config
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/netlify-forms-workaround/next.config.js
+++ b/tests/fixtures/netlify-forms-workaround/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/netlify-forms/next.config.js
+++ b/tests/fixtures/netlify-forms/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/nx-integrated/apps/custom-dist-dir/next.config.js
+++ b/tests/fixtures/nx-integrated/apps/custom-dist-dir/next.config.js
@@ -1,3 +1,4 @@
+const { join } = require('node:path')
 const { composePlugins, withNx } = require('@nx/next')
 
 /**
@@ -10,6 +11,7 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: false,
   },
+  outputFileTracingRoot: join(__dirname, '..', '..'),
 }
 
 const plugins = [

--- a/tests/fixtures/nx-integrated/apps/next-app/next.config.js
+++ b/tests/fixtures/nx-integrated/apps/next-app/next.config.js
@@ -1,3 +1,4 @@
+const { join } = require('node:path')
 const { composePlugins, withNx } = require('@nx/next')
 
 /**
@@ -9,6 +10,7 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: false,
   },
+  outputFileTracingRoot: join(__dirname, '..', '..'),
 }
 
 const plugins = [

--- a/tests/fixtures/output-export-custom-dist/next.config.js
+++ b/tests/fixtures/output-export-custom-dist/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/output-export/next.config.js
+++ b/tests/fixtures/output-export/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/page-router-404-get-static-props-with-revalidate/next.config.js
+++ b/tests/fixtures/page-router-404-get-static-props-with-revalidate/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/page-router-base-path-i18n/next.config.js
+++ b/tests/fixtures/page-router-base-path-i18n/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
     locales: ['en', 'fr', 'de'],
     defaultLocale: 'en',
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/page-router/next.config.js
+++ b/tests/fixtures/page-router/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
   generateBuildId: () => 'build-id',
 }
 

--- a/tests/fixtures/pnpm/next.config.js
+++ b/tests/fixtures/pnpm/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/ppr/next.config.js
+++ b/tests/fixtures/ppr/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   experimental: {
     ppr: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/revalidate-fetch/next.config.js
+++ b/tests/fixtures/revalidate-fetch/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/server-components/next.config.js
+++ b/tests/fixtures/server-components/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/simple/next.config.js
+++ b/tests/fixtures/simple/next.config.js
@@ -44,6 +44,7 @@ const nextConfig = {
       },
     ]
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/turborepo-npm/apps/page-router/next.config.js
+++ b/tests/fixtures/turborepo-npm/apps/page-router/next.config.js
@@ -1,3 +1,5 @@
+const { join } = require('node:path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -5,6 +7,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   transpilePackages: ['@repo/ui'],
+  outputFileTracingRoot: join(__dirname, '..', '..'),
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/turborepo/apps/page-router/next.config.js
+++ b/tests/fixtures/turborepo/apps/page-router/next.config.js
@@ -1,3 +1,5 @@
+const { join } = require('node:path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -5,6 +7,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   transpilePackages: ['@repo/ui'],
+  outputFileTracingRoot: join(__dirname, '..', '..'),
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/use-cache/next.config.js
+++ b/tests/fixtures/use-cache/next.config.js
@@ -30,6 +30,7 @@ const nextConfig = {
       },
     },
   },
+  outputFileTracingRoot: __dirname,
 }
 
 module.exports = nextConfig

--- a/tests/fixtures/wasm-src/next.config.js
+++ b/tests/fixtures/wasm-src/next.config.js
@@ -27,4 +27,5 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }

--- a/tests/fixtures/wasm/next.config.js
+++ b/tests/fixtures/wasm/next.config.js
@@ -27,4 +27,5 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  outputFileTracingRoot: __dirname,
 }


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

```
We detected multiple lockfiles and selected the directory of /home/runner/work/opennextjs-netlify/opennextjs-netlify/package-lock.json as the root directory.
To silence this warning, set `outputFileTracingRoot` in your Next.js config, or consider removing one of the lockfiles if it's not needed.
  See https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats for more information.
Detected additional lockfiles: 
  * /home/runner/work/opennextjs-netlify/opennextjs-netlify/tests/fixtures/base-path/package-lock.json
[base-path] 
⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
```

`next@canary` started treating our non workspaces fixtures as workspaces and result in whole setup breaking, this uses recommended setting to ensure fixture directories are treated as "file tracing roots"

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
