### PR TITLE
chore: rename netlify-cdn-cache-control and netlify-cache-tag

### DIFF
--- a/tests/e2e/cli-before-regional-blobs-support.test.ts
+++ b/tests/e2e/cli-before-regional-blobs-support.test.ts
@@ -23,7 +23,7 @@ test('should serve 404 page when requesting non existing page (no matching route
   // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that it
   // would not
   const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
-  expect(headers['netlify-cdn-cache-control']).toBe(
+  expect(headers['debug-netlify-cdn-cache-control']).toBe(
     (shouldHavePrivateDirective ? 'private, ' : '') +
       'no-cache, no-store, max-age=0, must-revalidate, durable',
   )

--- a/tests/e2e/dynamic-cms.test.ts
+++ b/tests/e2e/dynamic-cms.test.ts
@@ -60,8 +60,8 @@ test.describe('Dynamic CMS', () => {
         expect(headers1['cache-status']).toMatch(
           /"Next.js"; fwd=miss\s*(,|\n)\s*"Netlify Durable"; fwd=uri-miss; stored\s*(, |\n)\s*"Netlify Edge"; fwd=miss/,
         )
-        expect(headers1['netlify-cache-tag']).toEqual(expectedCacheTag)
-        expect(headers1['netlify-cdn-cache-control']).toMatch(
+        expect(headers1['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
+        expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
           /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
 
@@ -79,8 +79,8 @@ test.describe('Dynamic CMS', () => {
         expect(headers2['cache-status']).toMatch(
           /"Next.js"; hit\s*(,|\n)\s*"Netlify Durable"; fwd=stale; ttl=[0-9]+; stored\s*(,|\n)\s*"Netlify Edge"; fwd=(stale|miss)/,
         )
-        expect(headers2['netlify-cache-tag']).toEqual(expectedCacheTag)
-        expect(headers2['netlify-cdn-cache-control']).toMatch(
+        expect(headers2['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
+        expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
           /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
 
@@ -98,8 +98,8 @@ test.describe('Dynamic CMS', () => {
         expect(headers3['cache-status']).toMatch(
           /"Next.js"; fwd=miss\s*(,|\n)\s*"Netlify Durable"; fwd=stale; ttl=[0-9]+; stored\s*(,|\n)\s*"Netlify Edge"; fwd=(stale|miss)/,
         )
-        expect(headers3['netlify-cache-tag']).toEqual(expectedCacheTag)
-        expect(headers3['netlify-cdn-cache-control']).toMatch(
+        expect(headers3['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
+        expect(headers3['debug-netlify-cdn-cache-control']).toMatch(
           /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
       })

--- a/tests/e2e/edge-middleware.test.ts
+++ b/tests/e2e/edge-middleware.test.ts
@@ -392,13 +392,15 @@ test.describe('RSC cache poisoning', () => {
 
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
-    expect(prefetchResponse.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /s-maxage=31536000/,
+    )
 
     const htmlResponse = await page.goto(`${middleware.url}/test/rewrite-to-cached-page`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
   })
 
   test('Middleware redirect', async ({ page, middleware }) => {
@@ -419,12 +421,14 @@ test.describe('RSC cache poisoning', () => {
 
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
-    expect(prefetchResponse.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /s-maxage=31536000/,
+    )
 
     const htmlResponse = await page.goto(`${middleware.url}/test/redirect-to-cached-page`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
   })
 })

--- a/tests/e2e/on-demand-app.test.ts
+++ b/tests/e2e/on-demand-app.test.ts
@@ -90,7 +90,7 @@ test.describe('app router on-demand revalidation', () => {
       const headers1 = response1?.headers() || {}
       expect(response1?.status()).toBe(200)
       expect(headers1['x-nextjs-cache']).toBeUndefined()
-      expect(headers1['netlify-cdn-cache-control']).toBe(
+      expect(headers1['debug-netlify-cdn-cache-control']).toBe(
         nextVersionSatisfies('>=15.0.0-canary.187')
           ? 's-maxage=31536000, durable'
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -120,7 +120,7 @@ test.describe('app router on-demand revalidation', () => {
         // as we reuse cached response
         expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
       }
-      expect(headers2['netlify-cdn-cache-control']).toBe(
+      expect(headers2['debug-netlify-cdn-cache-control']).toBe(
         nextVersionSatisfies('>=15.0.0-canary.187')
           ? 's-maxage=31536000, durable'
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -152,7 +152,7 @@ test.describe('app router on-demand revalidation', () => {
       const headers3 = response3?.headers() || {}
       expect(response3?.status()).toBe(200)
       expect(headers3?.['x-nextjs-cache']).toBeUndefined()
-      expect(headers3['netlify-cdn-cache-control']).toBe(
+      expect(headers3['debug-netlify-cdn-cache-control']).toBe(
         nextVersionSatisfies('>=15.0.0-canary.187')
           ? 's-maxage=31536000, durable'
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -181,7 +181,7 @@ test.describe('app router on-demand revalidation', () => {
         // as we reuse cached response
         expect(headers4['cache-status']).toMatch(/"Next.js"; hit/m)
       }
-      expect(headers4['netlify-cdn-cache-control']).toBe(
+      expect(headers4['debug-netlify-cdn-cache-control']).toBe(
         nextVersionSatisfies('>=15.0.0-canary.187')
           ? 's-maxage=31536000, durable'
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -158,9 +158,11 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         const fallbackWasServed =
           useFallback && headers1['cache-status'].includes('"Next.js"; fwd=miss')
         if (!fallbackWasServed) {
-          expect(headers1['netlify-cache-tag']).toBe(`_n_t_${encodeURI(pagePath).toLowerCase()}`)
+          expect(headers1['debug-netlify-cache-tag']).toBe(
+            `_n_t_${encodeURI(pagePath).toLowerCase()}`,
+          )
         }
-        expect(headers1['netlify-cdn-cache-control']).toBe(
+        expect(headers1['debug-netlify-cdn-cache-control']).toBe(
           fallbackWasServed
             ? // fallback should not be cached
               nextVersionSatisfies('>=15.4.0-canary.95')
@@ -199,8 +201,10 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         const headers1Json = response1Json?.headers() || {}
         expect(response1Json?.status()).toBe(200)
         expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-        expect(headers1Json['netlify-cache-tag']).toBe(`_n_t_${encodeURI(pagePath).toLowerCase()}`)
-        expect(headers1Json['netlify-cdn-cache-control']).toBe(
+        expect(headers1Json['debug-netlify-cache-tag']).toBe(
+          `_n_t_${encodeURI(pagePath).toLowerCase()}`,
+        )
+        expect(headers1Json['debug-netlify-cdn-cache-control']).toBe(
           nextVersionSatisfies('>=15.0.0-canary.187')
             ? 's-maxage=31536000, durable'
             : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -227,7 +231,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
           // as we reuse cached response
           expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
         }
-        expect(headers2['netlify-cdn-cache-control']).toBe(
+        expect(headers2['debug-netlify-cdn-cache-control']).toBe(
           nextVersionSatisfies('>=15.0.0-canary.187')
             ? 's-maxage=31536000, durable'
             : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -260,7 +264,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
           // as we reuse cached response
           expect(headers2Json['cache-status']).toMatch(/"Next.js"; hit/m)
         }
-        expect(headers2Json['netlify-cdn-cache-control']).toBe(
+        expect(headers2Json['debug-netlify-cdn-cache-control']).toBe(
           nextVersionSatisfies('>=15.0.0-canary.187')
             ? 's-maxage=31536000, durable'
             : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -317,7 +321,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
         const headers3Json = response3Json?.headers() || {}
         expect(response3Json?.status()).toBe(200)
         expect(headers3Json['x-nextjs-cache']).toBeUndefined()
-        expect(headers3Json['netlify-cdn-cache-control']).toBe(
+        expect(headers3Json['debug-netlify-cdn-cache-control']).toBe(
           nextVersionSatisfies('>=15.0.0-canary.187')
             ? 's-maxage=31536000, durable'
             : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -407,7 +411,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     expect(response1?.headers()['cache-status']).toMatch(
       /"Netlify (Edge|Durable)"; fwd=(uri-miss(; stored)?|miss)/m,
     )
-    expect(response1?.headers()['netlify-cdn-cache-control']).toMatch(
+    expect(response1?.headers()['debug-netlify-cdn-cache-control']).toMatch(
       /s-maxage=60, stale-while-revalidate=[0-9]+, durable/,
     )
 
@@ -423,7 +427,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     expect(response2?.headers()['cache-status']).toMatch(
       /("Netlify Edge"; hit; fwd=stale|"Netlify Durable"; hit; ttl=-[0-9]+)/m,
     )
-    expect(response2?.headers()['netlify-cdn-cache-control']).toMatch(
+    expect(response2?.headers()['debug-netlify-cdn-cache-control']).toMatch(
       /s-maxage=60, stale-while-revalidate=[0-9]+, durable/,
     )
 
@@ -442,7 +446,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
       // hit, without being followed by ';fwd=stale' for edge or negative TTL for durable, optionally with fwd=stale
       /("Netlify Edge"; hit(?!; fwd=stale)|"Netlify Durable"; hit(?!; ttl=-[0-9]+))/m,
     )
-    expect(response3?.headers()['netlify-cdn-cache-control']).toMatch(
+    expect(response3?.headers()['debug-netlify-cdn-cache-control']).toMatch(
       /s-maxage=60, stale-while-revalidate=[0-9]+, durable/,
     )
 
@@ -471,7 +475,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     // after that (14.2.10 and canary.147) 404 pages would have `private` directive, before that
     // it would not
     const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
-    expect(headers['netlify-cdn-cache-control']).toBe(
+    expect(headers['debug-netlify-cdn-cache-control']).toBe(
       (shouldHavePrivateDirective ? 'private, ' : '') +
         'no-cache, no-store, max-age=0, must-revalidate, durable',
     )
@@ -491,7 +495,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
 
     expect(await page.textContent('p')).toBe('Custom 404 page')
 
-    expect(headers['netlify-cdn-cache-control']).toBe(
+    expect(headers['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -538,7 +542,7 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     const response = await page.goto(new URL('static/fully-static', pageRouter.url).href)
     const headers = response?.headers() || {}
 
-    expect(headers['netlify-cdn-cache-control']).toBe('max-age=31536000, durable')
+    expect(headers['debug-netlify-cdn-cache-control']).toBe('max-age=31536000, durable')
     expect(headers['cache-control']).toBe('public,max-age=0,must-revalidate')
   })
 
@@ -606,7 +610,9 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     )
 
     expect(response?.status()).toEqual(200)
-    expect(response?.headers()['netlify-cdn-cache-control'] ?? '').not.toMatch(/(s-maxage|max-age)/)
+    expect(response?.headers()['debug-netlify-cdn-cache-control'] ?? '').not.toMatch(
+      /(s-maxage|max-age)/,
+    )
   })
 })
 
@@ -726,11 +732,11 @@ test.describe('Page Router with basePath and i18n', () => {
             useFallback && headers1ImplicitLocale['cache-status'].includes('"Next.js"; fwd=miss')
 
           if (!fallbackWasServedImplicitLocale) {
-            expect(headers1ImplicitLocale['netlify-cache-tag']).toBe(
+            expect(headers1ImplicitLocale['debug-netlify-cache-tag']).toBe(
               `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
             )
           }
-          expect(headers1ImplicitLocale['netlify-cdn-cache-control']).toBe(
+          expect(headers1ImplicitLocale['debug-netlify-cdn-cache-control']).toBe(
             fallbackWasServedImplicitLocale
               ? // fallback should not be cached
                 nextVersionSatisfies('>=15.4.0-canary.95')
@@ -770,12 +776,12 @@ test.describe('Page Router with basePath and i18n', () => {
 
           const fallbackWasServedExplicitLocale =
             useFallback && headers1ExplicitLocale['cache-status'].includes('"Next.js"; fwd=miss')
-          expect(headers1ExplicitLocale['netlify-cache-tag']).toBe(
+          expect(headers1ExplicitLocale['debug-netlify-cache-tag']).toBe(
             fallbackWasServedExplicitLocale
               ? undefined
               : `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
           )
-          expect(headers1ExplicitLocale['netlify-cdn-cache-control']).toBe(
+          expect(headers1ExplicitLocale['debug-netlify-cdn-cache-control']).toBe(
             fallbackWasServedExplicitLocale
               ? undefined
               : nextVersionSatisfies('>=15.0.0-canary.187')
@@ -815,10 +821,10 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1Json = response1Json?.headers() || {}
           expect(response1Json?.status()).toBe(200)
           expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-          expect(headers1Json['netlify-cache-tag']).toBe(
+          expect(headers1Json['debug-netlify-cache-tag']).toBe(
             `_n_t_/en${encodeURI(pagePath).toLowerCase()}`,
           )
-          expect(headers1Json['netlify-cdn-cache-control']).toBe(
+          expect(headers1Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -848,7 +854,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers2ImplicitLocale['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2ImplicitLocale['netlify-cdn-cache-control']).toBe(
+          expect(headers2ImplicitLocale['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -880,7 +886,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers2ExplicitLocale['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2ExplicitLocale['netlify-cdn-cache-control']).toBe(
+          expect(headers2ExplicitLocale['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -913,7 +919,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers2Json['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2Json['netlify-cdn-cache-control']).toBe(
+          expect(headers2Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1009,7 +1015,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers3Json['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers3Json['netlify-cdn-cache-control']).toBe(
+          expect(headers3Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1100,7 +1106,7 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers4Json = response4Json?.headers() || {}
           expect(response4Json?.status()).toBe(200)
           expect(headers4Json['x-nextjs-cache']).toBeUndefined()
-          expect(headers4Json['netlify-cdn-cache-control']).toBe(
+          expect(headers4Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1151,11 +1157,11 @@ test.describe('Page Router with basePath and i18n', () => {
           const fallbackWasServed =
             useFallback && headers1['cache-status'].includes('"Next.js"; fwd=miss')
           if (!fallbackWasServed) {
-            expect(headers1['netlify-cache-tag']).toBe(
+            expect(headers1['debug-netlify-cache-tag']).toBe(
               `_n_t_/de${encodeURI(pagePath).toLowerCase()}`,
             )
           }
-          expect(headers1['netlify-cdn-cache-control']).toBe(
+          expect(headers1['debug-netlify-cdn-cache-control']).toBe(
             fallbackWasServed
               ? // fallback should not be cached
                 nextVersionSatisfies('>=15.4.0-canary.95')
@@ -1195,10 +1201,10 @@ test.describe('Page Router with basePath and i18n', () => {
           const headers1Json = response1Json?.headers() || {}
           expect(response1Json?.status()).toBe(200)
           expect(headers1Json['x-nextjs-cache']).toBeUndefined()
-          expect(headers1Json['netlify-cache-tag']).toBe(
+          expect(headers1Json['debug-netlify-cache-tag']).toBe(
             `_n_t_/de${encodeURI(pagePath).toLowerCase()}`,
           )
-          expect(headers1Json['netlify-cdn-cache-control']).toBe(
+          expect(headers1Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1228,7 +1234,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2['netlify-cdn-cache-control']).toBe(
+          expect(headers2['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1262,7 +1268,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers2Json['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2Json['netlify-cdn-cache-control']).toBe(
+          expect(headers2Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1331,7 +1337,7 @@ test.describe('Page Router with basePath and i18n', () => {
             // as we reuse cached response
             expect(headers3Json['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers3Json['netlify-cdn-cache-control']).toBe(
+          expect(headers3Json['debug-netlify-cdn-cache-control']).toBe(
             nextVersionSatisfies('>=15.0.0-canary.187')
               ? 's-maxage=31536000, durable'
               : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -1357,7 +1363,7 @@ test.describe('Page Router with basePath and i18n', () => {
     // https://github.com/vercel/next.js/pull/69802 made changes to returned cache-control header,
     // after that 404 pages would have `private` directive, before that it would not
     const shouldHavePrivateDirective = nextVersionSatisfies('^14.2.10 || >=15.0.0-canary.147')
-    expect(headers['netlify-cdn-cache-control']).toBe(
+    expect(headers['debug-netlify-cdn-cache-control']).toBe(
       (shouldHavePrivateDirective ? 'private, ' : '') +
         'no-cache, no-store, max-age=0, must-revalidate, durable',
     )
@@ -1377,7 +1383,7 @@ test.describe('Page Router with basePath and i18n', () => {
 
     expect(await page.textContent('p')).toBe('Custom 404 page')
 
-    expect(headers['netlify-cdn-cache-control']).toBe(
+    expect(headers['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -237,7 +237,7 @@ test('requesting a non existing page route that needs to be fetched from the blo
     '<14.2.4 || >=14.2.10 <15.0.0-canary.24 || ^15.0.0-canary.147',
   )
 
-  expect(headers['netlify-cdn-cache-control']).toBe(
+  expect(headers['debug-netlify-cdn-cache-control']).toBe(
     (shouldHavePrivateDirective ? 'private, ' : '') +
       'no-cache, no-store, max-age=0, must-revalidate, durable',
   )
@@ -256,7 +256,7 @@ test('requesting a non existing page route that needs to be fetched from the blo
 
   expect(await page.textContent('h1')).toBe('404 Not Found')
 
-  expect(headers['netlify-cdn-cache-control']).toBe(
+  expect(headers['debug-netlify-cdn-cache-control']).toBe(
     nextVersionSatisfies('>=15.0.0-canary.187')
       ? 's-maxage=31536000, durable'
       : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -302,13 +302,15 @@ test.describe('RSC cache poisoning', () => {
 
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
-    expect(prefetchResponse.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /s-maxage=31536000/,
+    )
 
     const htmlResponse = await page.goto(`${simple.url}/config-rewrite/source`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
   })
 
   test('Next.config.js redirect', async ({ page, simple }) => {
@@ -329,12 +331,14 @@ test.describe('RSC cache poisoning', () => {
 
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
-    expect(prefetchResponse.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /s-maxage=31536000/,
+    )
 
     const htmlResponse = await page.goto(`${simple.url}/config-rewrite/source`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
   })
 })

--- a/tests/e2e/turborepo.test.ts
+++ b/tests/e2e/turborepo.test.ts
@@ -35,7 +35,7 @@ test.describe('[PNPM] Package manager', () => {
     const headers1 = response1?.headers() || {}
     expect(response1?.status()).toBe(200)
     expect(headers1['x-nextjs-cache']).toBeUndefined()
-    expect(headers1['netlify-cdn-cache-control']).toBe(
+    expect(headers1['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -67,7 +67,7 @@ test.describe('[PNPM] Package manager', () => {
       // as we reuse cached response
       expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
     }
-    expect(headers2['netlify-cdn-cache-control']).toBe(
+    expect(headers2['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -143,7 +143,7 @@ test.describe('[NPM] Package manager', () => {
     const headers1 = response1?.headers() || {}
     expect(response1?.status()).toBe(200)
     expect(headers1['x-nextjs-cache']).toBeUndefined()
-    expect(headers1['netlify-cdn-cache-control']).toBe(
+    expect(headers1['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
@@ -175,7 +175,7 @@ test.describe('[NPM] Package manager', () => {
       // as we reuse cached response
       expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
     }
-    expect(headers2['netlify-cdn-cache-control']).toBe(
+    expect(headers2['debug-netlify-cdn-cache-control']).toBe(
       nextVersionSatisfies('>=15.0.0-canary.187')
         ? 's-maxage=31536000, durable'
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Our e2e are affected by a recent platform change and require the following values to be renamed:
- `netlify-cdn-cache-control` -> `debug-netlify-cdn-cache-control`
- `netlify-cache-tag` -> `debug-netlify-cache-tag`

See https://github.com/netlify/stargate/pull/2987