### PR TITLE
fix: revert "fix(perf): exclude `/_next/static/*` from generated functions (#3100)"

### DIFF
--- a/src/build/functions/server.ts
+++ b/src/build/functions/server.ts
@@ -106,7 +106,6 @@ const getHandlerFile = async (ctx: PluginContext): Promise<string> => {
 
   const templateVariables: Record<string, string> = {
     '{{useRegionalBlobs}}': ctx.useRegionalBlobs.toString(),
-    '{{excludeStaticPath}}': posixJoin(ctx.buildConfig.basePath || '', '/_next/static/*'),
   }
   // In this case it is a monorepo and we need to use a own template for it
   // as we have to change the process working directory

--- a/src/build/templates/handler-monorepo.tmpl.js
+++ b/src/build/templates/handler-monorepo.tmpl.js
@@ -49,9 +49,4 @@ export default async function (req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
-  excludedPath: [
-    // We use `preferStatic: true` so we already won't run this on *existing* static assets,
-    // but by excluding this entire path we also avoid invoking the function just to 404.
-    '{{excludeStaticPath}}',
-  ],
 }

--- a/src/build/templates/handler.tmpl.js
+++ b/src/build/templates/handler.tmpl.js
@@ -43,9 +43,4 @@ export default async function handler(req, context) {
 export const config = {
   path: '/*',
   preferStatic: true,
-  excludedPath: [
-    // We use `preferStatic: true` so we already won't run this on *existing* static assets,
-    // but by excluding this entire path we also avoid invoking the function just to 404.
-    '{{excludeStaticPath}}',
-  ],
 }

--- a/tests/e2e/page-router.test.ts
+++ b/tests/e2e/page-router.test.ts
@@ -1,8 +1,6 @@
 import { expect } from '@playwright/test'
 import { nextVersionSatisfies } from '../utils/next-version-helpers.mjs'
 import { test } from '../utils/playwright-helpers.js'
-import { join } from 'node:path'
-import { readdir } from 'node:fs/promises'
 
 export function waitFor(millis: number) {
   return new Promise((resolve) => setTimeout(resolve, millis))
@@ -615,34 +613,6 @@ test.describe('Simple Page Router (no basePath, no i18n)', () => {
     expect(response?.headers()['debug-netlify-cdn-cache-control'] ?? '').not.toMatch(
       /(s-maxage|max-age)/,
     )
-  })
-
-  test.describe('static assets and function invocations', () => {
-    test('should return 200 for an existing static asset without invoking a function', async ({
-      page,
-      pageRouter,
-    }) => {
-      // Since assets are hashed, we can't hardcode anything here. Find something to fetch.
-      const [staticAsset] = await readdir(
-        join(pageRouter.isolatedFixtureRoot, '.next', 'static', 'chunks'),
-      )
-      expect(staticAsset).toBeDefined()
-
-      const response = await page.goto(`${pageRouter.url}/_next/static/chunks/${staticAsset}`)
-
-      expect(response?.status()).toBe(200)
-      expect(response?.headers()).not.toHaveProperty('x-nf-function-type')
-    })
-
-    test('should return 404 for a nonexistent static asset without invoking a function', async ({
-      page,
-      pageRouter,
-    }) => {
-      const response = await page.goto(`${pageRouter.url}/_next/static/stale123abcdef.js`)
-
-      expect(response?.status()).toBe(404)
-      expect(response?.headers()).not.toHaveProperty('x-nf-function-type')
-    })
   })
 })
 
@@ -1382,15 +1352,13 @@ test.describe('Page Router with basePath and i18n', () => {
 
   test('requesting a non existing page route that needs to be fetched from the blob store like 404.html', async ({
     page,
-    pageRouterBasePathI18n,
+    pageRouter,
   }) => {
-    const response = await page.goto(
-      new URL('base/path/non-existing', pageRouterBasePathI18n.url).href,
-    )
+    const response = await page.goto(new URL('non-existing', pageRouter.url).href)
     const headers = response?.headers() || {}
     expect(response?.status()).toBe(404)
 
-    expect(await page.textContent('p')).toBe('Custom 404 page for locale: en')
+    expect(await page.textContent('p')).toBe('Custom 404 page')
 
     expect(headers['debug-netlify-cdn-cache-control']).toMatch(
       /no-cache, no-store, max-age=0, must-revalidate, durable/m,
@@ -1400,15 +1368,13 @@ test.describe('Page Router with basePath and i18n', () => {
 
   test('requesting a non existing page route that needs to be fetched from the blob store like 404.html (notFound: true)', async ({
     page,
-    pageRouterBasePathI18n,
+    pageRouter,
   }) => {
-    const response = await page.goto(
-      new URL('base/path/static/not-found', pageRouterBasePathI18n.url).href,
-    )
+    const response = await page.goto(new URL('static/not-found', pageRouter.url).href)
     const headers = response?.headers() || {}
     expect(response?.status()).toBe(404)
 
-    expect(await page.textContent('p')).toBe('Custom 404 page for locale: en')
+    expect(await page.textContent('p')).toBe('Custom 404 page')
 
     // Prior to v14.2.4 notFound pages are not cacheable
     // https://github.com/vercel/next.js/pull/66674
@@ -1420,37 +1386,5 @@ test.describe('Page Router with basePath and i18n', () => {
       )
       expect(headers['cache-control']).toBe('public,max-age=0,must-revalidate')
     }
-  })
-
-  test.describe('static assets and function invocations', () => {
-    test('should return 200 for an existing static asset without invoking a function', async ({
-      page,
-      pageRouterBasePathI18n,
-    }) => {
-      // Since assets are hashed, we can't hardcode anything here. Find something to fetch.
-      const [staticAsset] = await readdir(
-        join(pageRouterBasePathI18n.isolatedFixtureRoot, '.next', 'static', 'chunks'),
-      )
-      expect(staticAsset).toBeDefined()
-
-      const response = await page.goto(
-        `${pageRouterBasePathI18n.url}/base/path/_next/static/chunks/${staticAsset}`,
-      )
-
-      expect(response?.status()).toBe(200)
-      expect(response?.headers()).not.toHaveProperty('x-nf-function-type')
-    })
-
-    test('should return 404 for a nonexistent static asset without invoking a function', async ({
-      page,
-      pageRouterBasePathI18n,
-    }) => {
-      const response = await page.goto(
-        `${pageRouterBasePathI18n.url}/base/path/_next/static/stale123abcdef.js`,
-      )
-
-      expect(response?.status()).toBe(404)
-      expect(response?.headers()).not.toHaveProperty('x-nf-function-type')
-    })
   })
 })

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -21,7 +21,6 @@ export interface DeployResult {
   deployID: string
   url: string
   logs: string
-  isolatedFixtureRoot: string
 }
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'berry'
@@ -91,7 +90,6 @@ export const createE2EFixture = async (fixture: string, config: E2EConfig = {}) 
       cleanup: _cleanup,
       deployID: result.deployID,
       url: result.url,
-      isolatedFixtureRoot: result.isolatedFixtureRoot,
     }
   } catch (error) {
     await _cleanup(true)
@@ -292,7 +290,6 @@ async function deploySite(
     url: `https://${deployID}--${siteName}.netlify.app`,
     deployID,
     logs: output,
-    isolatedFixtureRoot,
   }
 }
 

--- a/tests/utils/playwright-helpers.ts
+++ b/tests/utils/playwright-helpers.ts
@@ -98,7 +98,7 @@ export const test = base.extend<
         if (response.url().includes('/_next/static/')) {
           expect(
             response.headers()['cache-control'],
-            `_next/static asset (${response.url()}) should have immutable cache control`,
+            '_next/static assets should have immutable cache control',
           ).toContain('public,max-age=31536000,immutable')
         }
       })


### PR DESCRIPTION
This reverts commit 5e2813227aa439fc39bad993c51329833f502ea1.


## Description

https://github.com/opennextjs/opennextjs-netlify/pull/3100 caused not intended bug where `_next/static` 404s get `public,max-age=31536000, immutable` which is wrong - that should only be applied to 200s

Fixes https://github.com/opennextjs/opennextjs-netlify/issues/3119

BEGIN_COMMIT_OVERRIDE
fix: revert "fix(perf): exclude /_next/static/* from generated functions (#3100)"
END_COMMIT_OVERRIDE