### PR TITLE
chore: Revert "chore: NETLIFY_NEXT_PLUGIN_SKIP is now handled by builds"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,17 @@ import {
   verifyPublishDir,
 } from './build/verification.js'
 
+const skipPlugin =
+  process.env.NETLIFY_NEXT_PLUGIN_SKIP === 'true' || process.env.NETLIFY_NEXT_PLUGIN_SKIP === '1'
+const skipText = 'Skipping Next.js plugin due to NETLIFY_NEXT_PLUGIN_SKIP environment variable.'
 const tracer = wrapTracer(trace.getTracer('Next.js runtime'))
 
 export const onPreDev = async (options: NetlifyPluginOptions) => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onPreDev', async () => {
     const context = new PluginContext(options)
 
@@ -37,6 +45,11 @@ export const onPreDev = async (options: NetlifyPluginOptions) => {
 }
 
 export const onPreBuild = async (options: NetlifyPluginOptions) => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onPreBuild', async (span) => {
     // Enable Next.js standalone mode at build time
     process.env.NEXT_PRIVATE_STANDALONE = 'true'
@@ -55,6 +68,11 @@ export const onPreBuild = async (options: NetlifyPluginOptions) => {
 }
 
 export const onBuild = async (options: NetlifyPluginOptions) => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onBuild', async (span) => {
     const ctx = new PluginContext(options)
 
@@ -88,12 +106,22 @@ export const onBuild = async (options: NetlifyPluginOptions) => {
 }
 
 export const onPostBuild = async (options: NetlifyPluginOptions) => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onPostBuild', async () => {
     await publishStaticDir(new PluginContext(options))
   })
 }
 
 export const onSuccess = async () => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onSuccess', async () => {
     const prewarm = [process.env.DEPLOY_URL, process.env.DEPLOY_PRIME_URL, process.env.URL].filter(
       // If running locally then the deploy ID is a placeholder value. Filtering for `https://0--` removes it.
@@ -104,6 +132,11 @@ export const onSuccess = async () => {
 }
 
 export const onEnd = async (options: NetlifyPluginOptions) => {
+  if (skipPlugin) {
+    console.warn(skipText)
+    return
+  }
+
   await tracer.withActiveSpan('onEnd', async () => {
     await unpublishStaticDir(new PluginContext(options))
   })


### PR DESCRIPTION
This reverts commit ba13f81bdea974c1832b79d07828fbe9ccacd165.
Was accidentally pushed to `main` branch instead of a working branch