### PR TITLE
test: remove cache header check from export tests

### DIFF
--- a/tests/e2e/export.test.ts
+++ b/tests/e2e/export.test.ts
@@ -5,12 +5,9 @@ const expectImageWasLoaded = async (locator: Locator) => {
   expect(await locator.evaluate((img: HTMLImageElement) => img.naturalHeight)).toBeGreaterThan(0)
 }
 test('Renders the Home page correctly with output export', async ({ page, outputExport }) => {
-  const response = await page.goto(outputExport.url)
-  const headers = response?.headers() || {}
+  await page.goto(outputExport.url)
 
   await expect(page).toHaveTitle('Simple Next App')
-
-  expect(headers['cache-status']).toBe('"Netlify Edge"; fwd=miss')
 
   const h1 = page.locator('h1')
   await expect(h1).toHaveText('Home')
@@ -22,12 +19,9 @@ test('Renders the Home page correctly with output export and publish set to out'
   page,
   ouputExportPublishOut,
 }) => {
-  const response = await page.goto(ouputExportPublishOut.url)
-  const headers = response?.headers() || {}
+  await page.goto(ouputExportPublishOut.url)
 
   await expect(page).toHaveTitle('Simple Next App')
-
-  expect(headers['cache-status']).toBe('"Netlify Edge"; fwd=miss')
 
   const h1 = page.locator('h1')
   await expect(h1).toHaveText('Home')
@@ -39,12 +33,9 @@ test('Renders the Home page correctly with output export and custom dist dir', a
   page,
   outputExportCustomDist,
 }) => {
-  const response = await page.goto(outputExportCustomDist.url)
-  const headers = response?.headers() || {}
+  await page.goto(outputExportCustomDist.url)
 
   await expect(page).toHaveTitle('Simple Next App')
-
-  expect(headers['cache-status']).toBe('"Netlify Edge"; fwd=miss')
 
   const h1 = page.locator('h1')
   await expect(h1).toHaveText('Home')


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

These tests are quite flaky as they are competing to be the first cache hit on the home page, which isn't always guaranteed, especially on a fresh deploy. Since the cache header checks are not actually relevant to the test, I've opted to remove them entirely.

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
