### PR TITLE
fix: ensure we append cache statuses correctly

### DIFF
--- a/src/run/headers.test.ts
+++ b/src/run/headers.test.ts
@@ -553,29 +553,30 @@ describe('headers', () => {
     })
   })
 
-  describe("setCacheStatusHeader", () => {
-    test("should append the cache status if a cache status header already exists", () => {
+  describe('setCacheStatusHeader', () => {
+    test('should append the cache status if a cache status header already exists', () => {
       const headers = new Headers({
-        "Cache-Status": `"Netlify Durable"; hit; ttl=31535509"`,
-        "x-nextjs-cache": "MISS"
+        'Cache-Status': `"Netlify Durable"; hit; ttl=31535509"`,
+        'x-nextjs-cache': 'MISS',
       })
 
-      setCacheStatusHeader(headers, "MISS")
+      setCacheStatusHeader(headers, 'MISS')
 
-      expect(headers.get("Cache-Status")).toEqual(`"Netlify Durable"; hit; ttl=31535509", "Next.js"; fwd=miss`)
-      expect(headers.get("x-nextjs-cache")).toBeNull()
+      expect(headers.get('Cache-Status')).toEqual(
+        `"Netlify Durable"; hit; ttl=31535509", "Next.js"; fwd=miss`,
+      )
+      expect(headers.get('x-nextjs-cache')).toBeNull()
     })
 
-    test("should add the cache status if a cache status header does not exist", () => {
+    test('should add the cache status if a cache status header does not exist', () => {
       const headers = new Headers({
-        "x-nextjs-cache": "MISS"
+        'x-nextjs-cache': 'MISS',
       })
 
-      setCacheStatusHeader(headers, "MISS")
+      setCacheStatusHeader(headers, 'MISS')
 
-      expect(headers.get("Cache-Status")).toEqual(`"Next.js"; fwd=miss`)
-      expect(headers.get("x-nextjs-cache")).toBeNull()
+      expect(headers.get('Cache-Status')).toEqual(`"Next.js"; fwd=miss`)
+      expect(headers.get('x-nextjs-cache')).toBeNull()
     })
-
   })
 })

--- a/src/run/headers.ts
+++ b/src/run/headers.ts
@@ -270,11 +270,11 @@ export const setCacheControlHeaders = (
       headers.get('x-nextjs-cache') === 'STALE'
         ? 'public, max-age=0, must-revalidate, durable'
         : [
-          ...getHeaderValueArray(cacheControl).map((value) =>
-            value === 'stale-while-revalidate' ? 'stale-while-revalidate=31536000' : value,
-          ),
-          'durable',
-        ].join(', ')
+            ...getHeaderValueArray(cacheControl).map((value) =>
+              value === 'stale-while-revalidate' ? 'stale-while-revalidate=31536000' : value,
+            ),
+            'durable',
+          ].join(', ')
 
     headers.set('cache-control', browserCacheControl || 'public, max-age=0, must-revalidate')
     headers.set('netlify-cdn-cache-control', cdnCacheControl)
@@ -331,10 +331,7 @@ export const setCacheStatusHeader = (headers: Headers, nextCache: string | null)
 
       const nextEntry = `"Next.js"; ${cacheStatus}`
 
-      headers.set(
-        'cache-status',
-        existing ? `${existing}, ${nextEntry}` : nextEntry
-      )
+      headers.set('cache-status', existing ? `${existing}, ${nextEntry}` : nextEntry)
     }
 
     headers.delete('x-nextjs-cache')


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

We need to ensure that the `Cache-Status` header is a valid format when there are multiple cache statuses.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
