### PR TITLE
fix: handle PPR shells for fully dynamic segments on Next.js 16.1.0+

### DIFF
--- a/src/build/content/prerendered.ts
+++ b/src/build/content/prerendered.ts
@@ -269,6 +269,8 @@ export const copyPrerenderedContent = async (ctx: PluginContext): Promise<void> 
             const value = await buildAppCacheValue(
               join(ctx.publishDir, 'server/app', key),
               shouldUseAppPageKind,
+              // shells always have `renderingMode === 'PARTIALLY_STATIC'`
+              false,
             )
 
             await writeCacheEntry(key, value, Date.now(), ctx)

--- a/tests/fixtures/ppr/app/dynamic-params/[id]/page.js
+++ b/tests/fixtures/ppr/app/dynamic-params/[id]/page.js
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// no `generateStaticParams` export
+
+async function getData(id) {
+  await connection()
+  const res = await fetch(`https://api.tvmaze.com/shows/${id}`, {
+    next: {
+      tags: [`show-${id}`],
+    },
+  })
+  await new Promise((res) => setTimeout(res, 3000))
+  return res.json()
+}
+
+async function Content({ id }) {
+  const data = await getData(await id)
+
+  return (
+    <>
+      <h1>Dynamic Page (dynamic params): {id}</h1>
+      <dl>
+        <dt>Show</dt>
+        <dd>{data.name}</dd>
+        <dt>Param</dt>
+        <dd>{await id}</dd>
+        <dt>Time</dt>
+        <dd data-testid="date-now">{new Date().toISOString()}</dd>
+      </dl>
+    </>
+  )
+}
+
+// This is a dynamic page (segment) where params are NOT statically generated (dynamic, at request time)
+export default async function DynamicPageWithDynamicParams({ params }) {
+  return (
+    <main>
+      <Suspense fallback={<div>loading...</div>}>
+        <Content id={params.then(({ id }) => id)} />
+      </Suspense>
+    </main>
+  )
+}

--- a/tests/fixtures/ppr/app/static-params/[id]/page.js
+++ b/tests/fixtures/ppr/app/static-params/[id]/page.js
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { connection } from 'next/server'
 
 export async function generateStaticParams() {
-  return [{ dynamic: '1' }, { dynamic: '2' }]
+  return [{ id: '1' }, { id: '2' }]
 }
 
 async function getData(params) {
@@ -31,14 +31,15 @@ async function Content(params) {
   )
 }
 
-export default async function DynamicPage({ params }) {
-  const { dynamic } = await params
+// This is a dynamic page (segment) where all params are statically generated
+export default async function DynamicPageWithStaticParams({ params }) {
+  const { id } = await params
 
   return (
     <main>
-      <h1>Dynamic Page: {dynamic}</h1>
+      <h1>Dynamic Page (static params): {id}</h1>
       <Suspense fallback={<div>loading...</div>}>
-        <Content id={dynamic} />
+        <Content id={id} />
       </Suspense>
     </main>
   )

--- a/tests/fixtures/ppr/package.json
+++ b/tests/fixtures/ppr/package.json
@@ -8,7 +8,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "semver": "^7.7.2"


### PR DESCRIPTION
## Description

The previous fix (https://github.com/opennextjs/opennextjs-netlify/pull/3275) made `.rsc` files optional for entries in `manifest.routes` with `renderingMode === 'PARTIALLY_STATIC'`. However, actual PPR shells are processed through another code path that wasn't updated in this way.

[When using Cache Components, routes _with_ or _without_ a `generateStaticParams` behave differently](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components). The former have no concrete prerendered pages (no known params at build time), only the shell. Such routes have a `fallback` pointing to the shell, but since the shell code path still requires `.rsc` files to be found, the build fails on Next.js `^16.1.0 || ^16.0.2-canary.29`, versions that [no longer emit these files](https://github.com/vercel/next.js/pull/86100).

### Documentation

https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components

## Tests

This PR adds integration tests for this scenario. They were failing before this fix.

There's also a repro here: https://github.com/serhalp/repro-nextjs-netlify-3344

## Relevant links (GitHub issues, etc.) or a picture of cute animal

Fixes #3344