### PR TITLE
fix: handle Next.js using cdn-cache-control for cacheable responses

### DIFF
--- a/src/run/headers.test.ts
+++ b/src/run/headers.test.ts
@@ -409,7 +409,7 @@ describe('headers', () => {
       )
     })
 
-    test('should not set any headers if "cache-control" is set and "cdn-cache-control" is present', () => {
+    test('should not set any headers if "cache-control" is set without x-nextjs-cache and "cdn-cache-control" is present', () => {
       const givenHeaders = {
         'cache-control': 'public, max-age=0, must-revalidate',
         'cdn-cache-control': 'public, max-age=0, must-revalidate',
@@ -423,7 +423,7 @@ describe('headers', () => {
       expect(response.headers.set).toHaveBeenCalledTimes(0)
     })
 
-    test('should not set any headers if "cache-control" is set and "netlify-cdn-cache-control" is present', () => {
+    test('should not set any headers if "cache-control" is set without x-nextjs-cache and "netlify-cdn-cache-control" is present', () => {
       const givenHeaders = {
         'cache-control': 'public, max-age=0, must-revalidate',
         'netlify-cdn-cache-control': 'public, max-age=0, must-revalidate',
@@ -440,6 +440,7 @@ describe('headers', () => {
     test('should set expected headers if "cache-control" is set and "cdn-cache-control" and "netlify-cdn-cache-control" are not present (GET request)', () => {
       const givenHeaders = {
         'cache-control': 'public, max-age=0, must-revalidate',
+        'x-nextjs-cache': 'HIT',
       }
       const request = new Request(defaultUrl)
       const response = new Response(null, { headers: givenHeaders })
@@ -462,6 +463,7 @@ describe('headers', () => {
     test('should set expected headers if "cache-control" is set and "cdn-cache-control" and "netlify-cdn-cache-control" are not present (HEAD request)', () => {
       const givenHeaders = {
         'cache-control': 'public, max-age=0, must-revalidate',
+        'x-nextjs-cache': 'HIT',
       }
       const request = new Request(defaultUrl, { method: 'HEAD' })
       const response = new Response(null, { headers: givenHeaders })
@@ -497,6 +499,7 @@ describe('headers', () => {
     test('should remove "s-maxage" from "cache-control" header', () => {
       const givenHeaders = {
         'cache-control': 'public, s-maxage=604800',
+        'x-nextjs-cache': 'HIT',
       }
       const request = new Request(defaultUrl)
       const response = new Response(null, { headers: givenHeaders })
@@ -515,6 +518,7 @@ describe('headers', () => {
     test('should remove "stale-while-revalidate" from "cache-control" header', () => {
       const givenHeaders = {
         'cache-control': 'max-age=604800, stale-while-revalidate=86400',
+        'x-nextjs-cache': 'HIT',
       }
       const request = new Request(defaultUrl)
       const response = new Response(null, { headers: givenHeaders })
@@ -533,6 +537,7 @@ describe('headers', () => {
     test('should set default "cache-control" header if it contains only "s-maxage" and "stale-while-revalidate"', () => {
       const givenHeaders = {
         'cache-control': 's-maxage=604800, stale-while-revalidate=86400',
+        'x-nextjs-cache': 'HIT',
       }
       const request = new Request(defaultUrl)
       const response = new Response(null, { headers: givenHeaders })

--- a/tests/e2e/dynamic-cms.test.ts
+++ b/tests/e2e/dynamic-cms.test.ts
@@ -62,7 +62,7 @@ test.describe('Dynamic CMS', () => {
         )
         expect(headers1['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
+          /(max-age|s-maxage)=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
 
         // 2. Publish the blob, revalidate the dynamic page, and wait to regenerate
@@ -81,7 +81,7 @@ test.describe('Dynamic CMS', () => {
         )
         expect(headers2['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
+          /(max-age|s-maxage)=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
 
         // 4. Unpublish the blob, revalidate the dynamic page, and wait to regenerate
@@ -100,7 +100,7 @@ test.describe('Dynamic CMS', () => {
         )
         expect(headers3['debug-netlify-cache-tag']).toEqual(expectedCacheTag)
         expect(headers3['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000,( stale-while-revalidate=31536000,)? durable/,
+          /(max-age|s-maxage)=31536000,( stale-while-revalidate=31536000,)? durable/,
         )
       })
     }

--- a/tests/e2e/middleware.test.ts
+++ b/tests/e2e/middleware.test.ts
@@ -527,7 +527,7 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
         // ensure prefetch respond with RSC data
         expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
         expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000/,
+          /(max-age|s-maxage)=31536000/,
         )
 
         const htmlResponse = await page.goto(
@@ -537,7 +537,7 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
         // ensure we get HTML response
         expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
         expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000/,
+          /(max-age|s-maxage)=31536000/,
         )
       })
 
@@ -560,7 +560,7 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
         // ensure prefetch respond with RSC data
         expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
         expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000/,
+          /(max-age|s-maxage)=31536000/,
         )
 
         const htmlResponse = await page.goto(
@@ -570,7 +570,7 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
         // ensure we get HTML response
         expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
         expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(
-          /s-maxage=31536000/,
+          /(max-age|s-maxage)=31536000/,
         )
       })
     })

--- a/tests/e2e/on-demand-app.test.ts
+++ b/tests/e2e/on-demand-app.test.ts
@@ -90,9 +90,9 @@ test.describe('app router on-demand revalidation (pre Next 16 APIs)', () => {
       const headers1 = response1?.headers() || {}
       expect(response1?.status()).toBe(200)
       expect(headers1['x-nextjs-cache']).toBeUndefined()
-      expect(headers1['debug-netlify-cdn-cache-control']).toBe(
+      expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
         nextVersionSatisfies('>=15.0.0-canary.187')
-          ? 's-maxage=31536000, durable'
+          ? /(max-age|s-maxage)=31536000, durable/
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
       )
 
@@ -120,9 +120,9 @@ test.describe('app router on-demand revalidation (pre Next 16 APIs)', () => {
         // as we reuse cached response
         expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
       }
-      expect(headers2['debug-netlify-cdn-cache-control']).toBe(
+      expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
         nextVersionSatisfies('>=15.0.0-canary.187')
-          ? 's-maxage=31536000, durable'
+          ? /(max-age|s-maxage)=31536000, durable/
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
       )
 
@@ -152,9 +152,9 @@ test.describe('app router on-demand revalidation (pre Next 16 APIs)', () => {
       const headers3 = response3?.headers() || {}
       expect(response3?.status()).toBe(200)
       expect(headers3?.['x-nextjs-cache']).toBeUndefined()
-      expect(headers3['debug-netlify-cdn-cache-control']).toBe(
+      expect(headers3['debug-netlify-cdn-cache-control']).toMatch(
         nextVersionSatisfies('>=15.0.0-canary.187')
-          ? 's-maxage=31536000, durable'
+          ? /(max-age|s-maxage)=31536000, durable/
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
       )
 
@@ -181,9 +181,9 @@ test.describe('app router on-demand revalidation (pre Next 16 APIs)', () => {
         // as we reuse cached response
         expect(headers4['cache-status']).toMatch(/"Next.js"; hit/m)
       }
-      expect(headers4['debug-netlify-cdn-cache-control']).toBe(
+      expect(headers4['debug-netlify-cdn-cache-control']).toMatch(
         nextVersionSatisfies('>=15.0.0-canary.187')
-          ? 's-maxage=31536000, durable'
+          ? /(max-age|s-maxage)=31536000, durable/
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
       )
 
@@ -269,7 +269,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
             const headers1 = response1?.headers() || {}
             expect(response1?.status()).toBe(200)
             expect(headers1['x-nextjs-cache']).toBeUndefined()
-            expect(headers1['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+            expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
+              /(max-age|s-maxage)=31536000, durable/,
+            )
 
             const date1 = await page.getByTestId('date-now').textContent()
 
@@ -298,7 +300,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
               // as we reuse cached response
               expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
             }
-            expect(headers2['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+            expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
+              /(max-age|s-maxage)=31536000, durable/,
+            )
 
             // the page is cached
             const date2 = await page.getByTestId('date-now').textContent()
@@ -367,7 +371,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
               // as we reuse cached response
               expect(headers4['cache-status']).toMatch(/"Next.js"; hit/m)
             }
-            expect(headers4['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+            expect(headers4['debug-netlify-cdn-cache-control']).toMatch(
+              /(max-age|s-maxage)=31536000, durable/,
+            )
 
             // the page is cached
             const date4 = await page.getByTestId('date-now').textContent()
@@ -401,7 +407,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
             const headers5 = response5?.headers() || {}
             expect(response5?.status()).toBe(200)
             expect(headers5?.['x-nextjs-cache']).toBeUndefined()
-            expect(headers5['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+            expect(headers5['debug-netlify-cdn-cache-control']).toMatch(
+              /(max-age|s-maxage)=31536000, durable/,
+            )
 
             // the page has now an updated date
             const date5 = await page.getByTestId('date-now').textContent()
@@ -446,7 +454,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
           const headers1 = response1?.headers() || {}
           expect(response1?.status()).toBe(200)
           expect(headers1['x-nextjs-cache']).toBeUndefined()
-          expect(headers1['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+          expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
+            /(max-age|s-maxage)=31536000, durable/,
+          )
 
           const date1 = await page.getByTestId('date-now').textContent()
 
@@ -475,7 +485,9 @@ if (nextVersionSatisfies('>=16.0.0-alpha.0')) {
             // as we reuse cached response
             expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
           }
-          expect(headers2['debug-netlify-cdn-cache-control']).toBe('s-maxage=31536000, durable')
+          expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
+            /(max-age|s-maxage)=31536000, durable/,
+          )
 
           // the page is cached
           const date2 = await page.getByTestId('date-now').textContent()

--- a/tests/e2e/simple-app.test.ts
+++ b/tests/e2e/simple-app.test.ts
@@ -256,9 +256,9 @@ test('requesting a non existing page route that needs to be fetched from the blo
 
   await expect(page.locator('h1')).toHaveText('404 Not Found')
 
-  expect(headers['debug-netlify-cdn-cache-control']).toBe(
+  expect(headers['debug-netlify-cdn-cache-control']).toMatch(
     nextVersionSatisfies('>=15.0.0-canary.187')
-      ? 's-maxage=31536000, durable'
+      ? /(max-age|s-maxage)=31536000, durable/
       : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
   )
   expect(headers['cache-control']).toBe('public,max-age=0,must-revalidate')
@@ -305,14 +305,16 @@ test.describe('RSC cache poisoning', () => {
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
     expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
-      /s-maxage=31536000/,
+      /(max-age|s-maxage)=31536000/,
     )
 
     const htmlResponse = await page.goto(`${simple.url}/config-rewrite/source`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /(max-age|s-maxage)=31536000/,
+    )
   })
 
   test('Next.config.js redirect', async ({ page, simple }) => {
@@ -334,14 +336,16 @@ test.describe('RSC cache poisoning', () => {
     // ensure prefetch respond with RSC data
     expect(prefetchResponse.headers()['content-type']).toMatch(/text\/x-component/)
     expect(prefetchResponse.headers()['debug-netlify-cdn-cache-control']).toMatch(
-      /s-maxage=31536000/,
+      /(max-age|s-maxage)=31536000/,
     )
 
     const htmlResponse = await page.goto(`${simple.url}/config-rewrite/source`)
 
     // ensure we get HTML response
     expect(htmlResponse?.headers()['content-type']).toMatch(/text\/html/)
-    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(/s-maxage=31536000/)
+    expect(htmlResponse?.headers()['debug-netlify-cdn-cache-control']).toMatch(
+      /(max-age|s-maxage)=31536000/,
+    )
   })
 })
 

--- a/tests/e2e/turborepo.test.ts
+++ b/tests/e2e/turborepo.test.ts
@@ -35,9 +35,9 @@ test.describe('[PNPM] Package manager', () => {
     const headers1 = response1?.headers() || {}
     expect(response1?.status()).toBe(200)
     expect(headers1['x-nextjs-cache']).toBeUndefined()
-    expect(headers1['debug-netlify-cdn-cache-control']).toBe(
+    expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
       nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? /(max-age|s-maxage)=31536000/
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     )
 
@@ -67,9 +67,9 @@ test.describe('[PNPM] Package manager', () => {
       // as we reuse cached response
       expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
     }
-    expect(headers2['debug-netlify-cdn-cache-control']).toBe(
+    expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
       nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? /(max-age|s-maxage)=31536000/
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     )
 
@@ -152,9 +152,9 @@ test.describe('[NPM] Package manager', () => {
     const headers1 = response1?.headers() || {}
     expect(response1?.status()).toBe(200)
     expect(headers1['x-nextjs-cache']).toBeUndefined()
-    expect(headers1['debug-netlify-cdn-cache-control']).toBe(
+    expect(headers1['debug-netlify-cdn-cache-control']).toMatch(
       nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? /(max-age|s-maxage)=31536000/
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     )
 
@@ -184,9 +184,9 @@ test.describe('[NPM] Package manager', () => {
       // as we reuse cached response
       expect(headers2['cache-status']).toMatch(/"Next.js"; hit/m)
     }
-    expect(headers2['debug-netlify-cdn-cache-control']).toBe(
+    expect(headers2['debug-netlify-cdn-cache-control']).toMatch(
       nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? /(max-age|s-maxage)=31536000/
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     )
 

--- a/tests/integration/cache-handler.test.ts
+++ b/tests/integration/cache-handler.test.ts
@@ -98,7 +98,7 @@ describe('page router', () => {
       expect.objectContaining({
         'cache-status': '"Next.js"; hit',
         'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-          ? `s-maxage=5, stale-while-revalidate=${31536000 - 5}, durable`
+          ? expect.stringMatching(/(s-maxage|max-age)=5, stale-while-revalidate=31535995, durable/)
           : 's-maxage=5, stale-while-revalidate=31536000, durable',
       }),
     )
@@ -255,7 +255,7 @@ describe('app router', () => {
       expect.objectContaining({
         'cache-status': '"Next.js"; hit',
         'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-          ? 's-maxage=31536000, durable'
+          ? expect.stringMatching(/(s-maxage|max-age)=31536000, durable/)
           : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
       }),
     )

--- a/tests/integration/fetch-handler.test.ts
+++ b/tests/integration/fetch-handler.test.ts
@@ -255,7 +255,7 @@ test<FixtureTestContext>('if the fetch call is cached correctly (cached page res
     expect.objectContaining({
       'cache-status': '"Next.js"; hit',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? `s-maxage=5, stale-while-revalidate=${31536000 - 5}, durable`
+        ? expect.stringMatching(/(s-maxage|max-age)=5, stale-while-revalidate=31535995, durable/)
         : 's-maxage=5, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -323,7 +323,7 @@ test<FixtureTestContext>('if the fetch call is cached correctly (cached page res
     expect.objectContaining({
       'cache-status': '"Next.js"; hit',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? `s-maxage=5, stale-while-revalidate=${31536000 - 5}, durable`
+        ? expect.stringMatching(/(s-maxage|max-age)=5, stale-while-revalidate=31535995, durable/)
         : 's-maxage=5, stale-while-revalidate=31536000, durable',
     }),
   )

--- a/tests/integration/revalidate-path.test.ts
+++ b/tests/integration/revalidate-path.test.ts
@@ -69,7 +69,7 @@ test<FixtureTestContext>('should revalidate a route by path', async (ctx) => {
     expect.objectContaining({
       'cache-status': expect.stringMatching(/"Next.js"; hit/),
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(s-maxage|max-age)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -86,7 +86,7 @@ test<FixtureTestContext>('should revalidate a route by path', async (ctx) => {
     expect.objectContaining({
       'cache-status': expect.stringMatching(/"Next.js"; hit/),
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(s-maxage|max-age)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -116,7 +116,7 @@ test<FixtureTestContext>('should revalidate a route by path', async (ctx) => {
     expect.objectContaining({
       'cache-status': '"Next.js"; fwd=miss',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -135,7 +135,7 @@ test<FixtureTestContext>('should revalidate a route by path', async (ctx) => {
     expect.objectContaining({
       'cache-status': '"Next.js"; fwd=miss',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )

--- a/tests/integration/revalidate-tags.test.ts
+++ b/tests/integration/revalidate-tags.test.ts
@@ -69,7 +69,7 @@ test<FixtureTestContext>('should revalidate a route by tag', async (ctx) => {
     expect.objectContaining({
       'cache-status': expect.stringMatching(/"Next.js"; hit/),
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -98,7 +98,7 @@ test<FixtureTestContext>('should revalidate a route by tag', async (ctx) => {
     expect.objectContaining({
       'cache-status': '"Next.js"; fwd=miss',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -123,7 +123,7 @@ test<FixtureTestContext>('should revalidate a route by tag', async (ctx) => {
     expect.objectContaining({
       'cache-status': expect.stringMatching(/"Next.js"; hit/),
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )
@@ -154,7 +154,7 @@ test<FixtureTestContext>('should revalidate a route by tag', async (ctx) => {
     expect.objectContaining({
       'cache-status': '"Next.js"; fwd=miss',
       'netlify-cdn-cache-control': nextVersionSatisfies('>=15.0.0-canary.187')
-        ? 's-maxage=31536000, durable'
+        ? expect.stringMatching(/(max-age|s-maxage)=31536000, durable/)
         : 's-maxage=31536000, stale-while-revalidate=31536000, durable',
     }),
   )

--- a/tests/integration/simple-app.test.ts
+++ b/tests/integration/simple-app.test.ts
@@ -373,8 +373,8 @@ test<FixtureTestContext>('cacheable route handler is cached on cdn (revalidate=1
   await new Promise((res) => setTimeout(res, 1_000))
 
   const secondTimeCachedResponse = await invokeFunction(ctx, { url: '/api/cached-revalidate' })
-  expect(secondTimeCachedResponse.headers['netlify-cdn-cache-control']).toBe(
-    's-maxage=15, stale-while-revalidate=31536000, durable',
+  expect(secondTimeCachedResponse.headers['netlify-cdn-cache-control']).toMatch(
+    /(max-age|s-maxage)=15, stale-while-revalidate=31536000, durable/,
   )
 })
 


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

See description of https://github.com/vercel/next.js/pull/86554

Next.js now prefer to use cdn-cache-control over cache-control for cdn caching. This adjusts our handling and also loosen up some netlify-cdn-cache-control assertions allowing either `s-maxage` or `max-age` directive for this header (that also changed and not just using cdn-cache-control)