### PR TITLE
test: cacheComponents fixture need to await params in Suspense

### DIFF
--- a/tests/fixtures/ppr/app/static-params/[id]/page.js
+++ b/tests/fixtures/ppr/app/static-params/[id]/page.js
@@ -16,7 +16,7 @@ async function getData(params) {
   return res.json()
 }
 
-async function Content(params) {
+async function FetchedDataContent(params) {
   const data = await getData(params)
 
   return (
@@ -31,15 +31,26 @@ async function Content(params) {
   )
 }
 
-// This is a dynamic page (segment) where all params are statically generated
-export default async function DynamicPageWithStaticParams({ params }) {
+// await params need to be in suspense block https://nextjs.org/docs/messages/blocking-route
+async function Content({ params }) {
   const { id } = await params
 
   return (
-    <main>
+    <>
       <h1>Dynamic Page (static params): {id}</h1>
-      <Suspense fallback={<div>loading...</div>}>
-        <Content id={id} />
+      <Suspense fallback={<div>loading content...</div>}>
+        <FetchedDataContent id={id} />
+      </Suspense>
+    </>
+  )
+}
+
+// This is a dynamic page (segment) where some params are statically generated
+export default async function DynamicPageWithStaticParams({ params }) {
+  return (
+    <main>
+      <Suspense fallback={<div>loading params...</div>}>
+        <Content params={params} />
       </Suspense>
     </main>
   )

--- a/tests/integration/simple-app.test.ts
+++ b/tests/integration/simple-app.test.ts
@@ -413,6 +413,7 @@ test.skipIf(
       '/index',
       '/static-params/1',
       '/static-params/2',
+      '/static-params/[id]',
       '404.html',
       '500.html',
     ].filter(Boolean),


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Our ppr / cacheComponents fixture was doing `await params` outside of Suspense boundary, which is now failing (since https://github.com/vercel/next.js/pull/92627 )

https://nextjs.org/docs/messages/blocking-route is relevant guidance for error we were getting

How does that affect behavior:
 - prerendered pages still will look the same and have same static shell available with `<h1>Dynamic Page (static params): {id}</h1>` from the start (in our tests that would be `id:1, `id:2` as defined in `generateStaticParams` export
 - not prerendered pages instead of blocking will first serve fallback static shell with `<div>loading params...</div>` fallback on first visit. `<h1>Dynamic Page (static params): {id}</h1>` will be streamed in to the client and also stored in cache (so shell for not prerendered page will be "upgraded" from fallback shell to materialized parameterized shell for this page)

So this basically mean that parameterized routes now have initial fallback shell instead of blocking on shell generation for given parameter if route was not prerendered