### PR TITLE
fix: matching on data routes when middleware matcher is using allowed paths

### DIFF
--- a/edge-runtime/lib/next-request.ts
+++ b/edge-runtime/lib/next-request.ts
@@ -7,6 +7,7 @@ import {
   normalizeDataUrl,
   normalizeLocalePath,
   removeBasePath,
+  rewriteDataPath,
 } from './util.ts'
 
 interface I18NConfig {
@@ -82,18 +83,32 @@ export const localizeRequest = (
   },
 ): { localizedUrl: URL; locale?: string } => {
   const localizedUrl = new URL(url)
-  localizedUrl.pathname = removeBasePath(localizedUrl.pathname, nextConfig?.basePath)
+  const pathnameWithoutBasePath = removeBasePath(localizedUrl.pathname, nextConfig?.basePath)
+
+  const isDataRequest = pathnameWithoutBasePath.startsWith('/_next/data/')
+
+  const normalizedPath = isDataRequest
+    ? normalizeDataUrl(pathnameWithoutBasePath)
+    : pathnameWithoutBasePath
 
   // Detect the locale from the URL
-  const { detectedLocale } = normalizeLocalePath(localizedUrl.pathname, nextConfig?.i18n?.locales)
+  const { detectedLocale } = normalizeLocalePath(normalizedPath, nextConfig?.i18n?.locales)
 
   // Add the locale to the URL if not already present
-  localizedUrl.pathname = addLocale(
-    localizedUrl.pathname,
+  const normalizedPathWithLocale = addLocale(
+    normalizedPath,
     detectedLocale ?? nextConfig?.i18n?.defaultLocale,
   )
 
-  localizedUrl.pathname = addBasePath(localizedUrl.pathname, nextConfig?.basePath)
+  localizedUrl.pathname = addBasePath(
+    isDataRequest
+      ? rewriteDataPath({
+          dataUrl: pathnameWithoutBasePath,
+          newRoute: normalizedPathWithLocale,
+        })
+      : normalizedPathWithLocale,
+    nextConfig?.basePath,
+  )
 
   return {
     localizedUrl,

--- a/edge-runtime/middleware.ts
+++ b/edge-runtime/middleware.ts
@@ -48,7 +48,12 @@ export async function handleMiddleware(
   if (
     !matchesMiddleware(localizedUrl.pathname, request, searchParamsToUrlQuery(url.searchParams))
   ) {
-    reqLogger.debug('Aborting middleware due to runtime rules')
+    reqLogger
+      .withFields({
+        next_original_url: url,
+        next_localized_url: localizedUrl.href,
+      })
+      .debug('Aborting middleware due to runtime rules')
 
     return
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "os": "^0.1.2",
         "outdent": "^0.8.0",
         "p-limit": "^6.0.0",
-        "path-to-regexp": "^6.2.1",
         "picomatch": "^4.0.2",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
@@ -31645,8 +31644,7 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "os": "^0.1.2",
     "outdent": "^0.8.0",
     "p-limit": "^6.0.0",
-    "path-to-regexp": "^6.2.1",
     "picomatch": "^4.0.2",
     "prettier": "^3.2.5",
     "semver": "^7.6.0",

--- a/src/build/functions/edge.ts
+++ b/src/build/functions/edge.ts
@@ -5,7 +5,6 @@ import type { Manifest, ManifestFunction } from '@netlify/edge-functions'
 import { glob } from 'fast-glob'
 import type { FunctionsConfigManifest } from 'next-with-cache-handler-v2/dist/build/index.js'
 import type { EdgeFunctionDefinition as EdgeMiddlewareDefinition } from 'next-with-cache-handler-v2/dist/build/webpack/plugins/middleware-plugin.js'
-import { pathToRegexp } from 'path-to-regexp'
 
 import { EDGE_HANDLER_NAME, PluginContext } from '../plugin-context.js'
 
@@ -56,6 +55,20 @@ const copyRuntime = async (ctx: PluginContext, handlerDirectory: string): Promis
   )
 }
 
+const fixEdgeRuntimeTurbopackMatcherJsonPart = (matchers: EdgeMiddlewareDefinition['matchers']) => {
+  return matchers.map((matcher) => {
+    if (matcher.regexp) {
+      return {
+        ...matcher,
+        // Next.js in some versions produces "\\\\.json" for edge runtime middleware when built with turbopack
+        // with too many escapes preventing proper matching
+        regexp: matcher.regexp.replaceAll('\\\\.json', '\\.json'),
+      }
+    }
+    return matcher
+  })
+}
+
 /**
  * When i18n is enabled the matchers assume that paths _always_ include the
  * locale. We manually add an extra matcher for the original path without
@@ -80,13 +93,18 @@ const augmentMatchers = (
               // Next is producing pretty broad matcher for i18n locale. Presumably rest of their infrastructure protects this broad matcher
               // from matching on non-locale paths. For us this becomes request entry point, so we need to narrow it down to just defined locales
               // otherwise users might get unexpected matches on paths like `/api*`
-              regexp: matcher.regexp.replace(/\[\^\/\.]+/g, `(${i18NConfig.locales.join('|')})`),
+              // additionally we don't have a way to normalize i18n paths for request without locale information, so we need to adjust the regexp to mark locale part as optional
+              regexp: matcher.regexp
+                // replace i18n part matching:
+                //  - target locales only
+                //  - make it optional to allow matching both with and without locale
+                // (?:\\/((?!_next\\/)[^/.]{1,}))
+                .replace(
+                  '(?:\\/((?!_next\\/)[^/.]{1,}))',
+                  `(?:\\/((?!_next\\/)(${i18NConfig.locales.join('|')}){1,}))?`,
+                ),
             }
           : matcher,
-        {
-          ...matcher,
-          regexp: pathToRegexp(matcher.originalSource).source,
-        },
       ]
     }
     return matcher
@@ -330,7 +348,7 @@ export const createEdgeHandlers = async (ctx: PluginContext) => {
       runtime: 'edge',
       functionDefinition: edgeDefinition,
       name: edgeDefinition.name,
-      matchers: edgeDefinition.matchers,
+      matchers: fixEdgeRuntimeTurbopackMatcherJsonPart(edgeDefinition.matchers),
     }
   })
 

--- a/tests/e2e/middleware.test.ts
+++ b/tests/e2e/middleware.test.ts
@@ -13,6 +13,8 @@ type ExtendedFixtures = {
   edgeOrNodeMiddlewarePages: Fixture
   edgeOrNodeMiddlewareI18n: Fixture
   edgeOrNodeMiddlewareI18nExcludedPaths: Fixture
+  edgeOrNodeMiddlewareI18nIncludedPaths: Fixture
+  edgeOrNodeMiddlewareIncludedPaths: Fixture
   edgeOrNodeMiddlewareStaticAssetMatcher: Fixture
 }
 
@@ -49,6 +51,22 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
       edgeOrNodeMiddlewareI18nExcludedPaths: [
         async ({ middlewareI18nExcludedPaths }, use) => {
           await use(middlewareI18nExcludedPaths)
+        },
+        {
+          scope: 'worker',
+        },
+      ],
+      edgeOrNodeMiddlewareI18nIncludedPaths: [
+        async ({ middlewareI18nIncludedPaths }, use) => {
+          await use(middlewareI18nIncludedPaths)
+        },
+        {
+          scope: 'worker',
+        },
+      ],
+      edgeOrNodeMiddlewareIncludedPaths: [
+        async ({ middlewareIncludedPaths }, use) => {
+          await use(middlewareIncludedPaths)
         },
         {
           scope: 'worker',
@@ -97,6 +115,22 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
           edgeOrNodeMiddlewareI18nExcludedPaths: [
             async ({ middlewareI18nExcludedPathsNode }, use) => {
               await use(middlewareI18nExcludedPathsNode)
+            },
+            {
+              scope: 'worker',
+            },
+          ],
+          edgeOrNodeMiddlewareI18nIncludedPaths: [
+            async ({ middlewareI18nIncludedPathsNode }, use) => {
+              await use(middlewareI18nIncludedPathsNode)
+            },
+            {
+              scope: 'worker',
+            },
+          ],
+          edgeOrNodeMiddlewareIncludedPaths: [
+            async ({ middlewareIncludedPathsNode }, use) => {
+              await use(middlewareIncludedPathsNode)
             },
             {
               scope: 'worker',
@@ -220,121 +254,236 @@ for (const { expectedRuntime, isNodeMiddleware, label, testWithSwitchableMiddlew
       }
 
       test.describe('no 18n', () => {
-        for (const testConfig of testConfigs) {
-          test.describe(testConfig.describeLabel, () => {
-            test('json data fetch', async ({ edgeOrNodeMiddlewarePages, page }) => {
-              const dataFetchPromise = new Promise<Response>((resolve) => {
-                page.on('response', (response) => {
-                  if (response.url().includes(testConfig.jsonPathMatcher)) {
-                    resolve(response)
-                  }
+        test.describe('without middleware matcher', () => {
+          for (const testConfig of testConfigs) {
+            test.describe(testConfig.describeLabel, () => {
+              test('json data fetch', async ({ edgeOrNodeMiddlewarePages, page }) => {
+                const dataFetchPromise = new Promise<Response>((resolve) => {
+                  page.on('response', (response) => {
+                    if (response.url().includes(testConfig.jsonPathMatcher)) {
+                      resolve(response)
+                    }
+                  })
                 })
+
+                const pageResponse = await page.goto(`${edgeOrNodeMiddlewarePages.url}/link`)
+                expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+
+                await page.hover(`[data-link="${testConfig.selector}"]`)
+
+                const dataResponse = await dataFetchPromise
+
+                expect(dataResponse.ok()).toBe(true)
+                expect(dataResponse.headers()['x-hello-from-middleware-res']).toBe('hello')
               })
 
-              const pageResponse = await page.goto(`${edgeOrNodeMiddlewarePages.url}/link`)
-              expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+              test('navigation', async ({ edgeOrNodeMiddlewarePages, page }) => {
+                const pageResponse = await page.goto(`${edgeOrNodeMiddlewarePages.url}/link`)
+                expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
 
-              await page.hover(`[data-link="${testConfig.selector}"]`)
+                // wait for hydration to finish before doing client navigation
+                await expect(page.getByTestId('hydration')).toHaveText('hydrated', {
+                  timeout: 10_000,
+                })
 
-              const dataResponse = await dataFetchPromise
+                await page.evaluate(() => {
+                  // set some value to window to check later if browser did reload and lost this state
+                  ;(window as ExtendedWindow).didReload = false
+                })
 
-              expect(dataResponse.ok()).toBe(true)
+                await page.click(`[data-link="${testConfig.selector}"]`)
+
+                // wait for page to be rendered
+                await page.waitForSelector(`[data-page="${testConfig.selector}"]`)
+
+                // check if browser navigation worked by checking if state was preserved
+                const browserNavigationWorked =
+                  (await page.evaluate(() => {
+                    return (window as ExtendedWindow).didReload
+                  })) === false
+
+                // we expect client navigation to work without browser reload
+                expect(browserNavigationWorked).toBe(true)
+              })
+            })
+          }
+        })
+
+        test.describe('with matcher for specific path', () => {
+          const testConfig = {
+            selector: 'test',
+            expectedPathname: '/test',
+            jsonPathMatcher: '/test.json',
+          }
+
+          test('json data prefetch', async ({ edgeOrNodeMiddlewareIncludedPaths, page }) => {
+            const dataFetchPromise = new Promise<Response>((resolve) => {
+              page.on('response', (response) => {
+                if (response.url().includes(testConfig.jsonPathMatcher)) {
+                  resolve(response)
+                }
+              })
             })
 
-            test('navigation', async ({ edgeOrNodeMiddlewarePages, page }) => {
-              const pageResponse = await page.goto(`${edgeOrNodeMiddlewarePages.url}/link`)
-              expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+            const pageResponse = await page.goto(`${edgeOrNodeMiddlewareIncludedPaths.url}/link`)
+            expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
 
-              // wait for hydration to finish before doing client navigation
-              await expect(page.getByTestId('hydration')).toHaveText('hydrated', {
-                timeout: 10_000,
-              })
+            await page.hover(`[data-link="${testConfig.selector}"]`)
 
-              await page.evaluate(() => {
-                // set some value to window to check later if browser did reload and lost this state
-                ;(window as ExtendedWindow).didReload = false
-              })
+            const dataResponse = await dataFetchPromise
 
-              await page.click(`[data-link="${testConfig.selector}"]`)
-
-              // wait for page to be rendered
-              await page.waitForSelector(`[data-page="${testConfig.selector}"]`)
-
-              // check if browser navigation worked by checking if state was preserved
-              const browserNavigationWorked =
-                (await page.evaluate(() => {
-                  return (window as ExtendedWindow).didReload
-                })) === false
-
-              // we expect client navigation to work without browser reload
-              expect(browserNavigationWorked).toBe(true)
-            })
+            expect(dataResponse.ok()).toBe(true)
+            expect(dataResponse.headers()['x-hello-from-middleware-res']).toBe('hello')
+            expect(dataResponse.headers()['x-pathname']).toBe(testConfig.expectedPathname)
+            expect(dataResponse.headers()['x-runtime']).toBe(expectedRuntime)
+            expect(dataResponse.headers()['x-locale']).toEqual('')
           })
-        }
+
+          test('direct json data fetch', async ({ edgeOrNodeMiddlewareIncludedPaths }) => {
+            const url = `${edgeOrNodeMiddlewareIncludedPaths.url}/_next/data/build-id${testConfig.jsonPathMatcher}`
+            const response = await fetch(url, {
+              headers: {
+                'x-nextjs-data': '1',
+              },
+            })
+
+            expect(response.headers.get('x-hello-from-middleware-res')).toBe('hello')
+            expect(response.headers.get('x-pathname')).toBe(testConfig.expectedPathname)
+            expect(response.headers.get('x-runtime')).toEqual(expectedRuntime)
+            expect(response.headers.get('x-locale')).toEqual('')
+          })
+        })
       })
 
       test.describe('with 18n', () => {
-        for (const testConfig of testConfigs) {
-          test.describe(testConfig.describeLabel, () => {
-            for (const { localeLabel, pageWithLinksPathname } of [
-              { localeLabel: 'implicit default locale', pageWithLinksPathname: '/link' },
-              { localeLabel: 'explicit default locale', pageWithLinksPathname: '/en/link' },
-              { localeLabel: 'explicit non-default locale', pageWithLinksPathname: '/fr/link' },
-            ]) {
-              test.describe(localeLabel, () => {
-                test('json data fetch', async ({ edgeOrNodeMiddlewareI18n, page }) => {
-                  const dataFetchPromise = new Promise<Response>((resolve) => {
-                    page.on('response', (response) => {
-                      if (response.url().includes(testConfig.jsonPathMatcher)) {
-                        resolve(response)
-                      }
+        for (const { localeLabel, pageWithLinksPathname, localePrefix, expectedLocale } of [
+          {
+            localeLabel: 'implicit default locale',
+            pageWithLinksPathname: '/link',
+            localePrefix: '',
+            expectedLocale: 'en',
+          },
+          {
+            localeLabel: 'explicit default locale',
+            pageWithLinksPathname: '/en/link',
+            localePrefix: '/en',
+            expectedLocale: 'en',
+          },
+          {
+            localeLabel: 'explicit non-default locale',
+            pageWithLinksPathname: '/fr/link',
+            localePrefix: '/fr',
+            expectedLocale: 'fr',
+          },
+        ]) {
+          test.describe(localeLabel, () => {
+            test.describe('without middleware matcher', () => {
+              for (const testConfig of testConfigs) {
+                test.describe(testConfig.describeLabel, () => {
+                  test('json data fetch', async ({ edgeOrNodeMiddlewareI18n, page }) => {
+                    const dataFetchPromise = new Promise<Response>((resolve) => {
+                      page.on('response', (response) => {
+                        if (response.url().includes(testConfig.jsonPathMatcher)) {
+                          resolve(response)
+                        }
+                      })
                     })
+
+                    const pageResponse = await page.goto(
+                      `${edgeOrNodeMiddlewareI18n.url}${pageWithLinksPathname}`,
+                    )
+                    expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+
+                    await page.hover(`[data-link="${testConfig.selector}"]`)
+
+                    const dataResponse = await dataFetchPromise
+
+                    expect(dataResponse.ok()).toBe(true)
+                    expect(dataResponse.headers()['x-hello-from-middleware-res']).toBe('hello')
                   })
 
-                  const pageResponse = await page.goto(
-                    `${edgeOrNodeMiddlewareI18n.url}${pageWithLinksPathname}`,
-                  )
-                  expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+                  test('navigation', async ({ edgeOrNodeMiddlewareI18n, page }) => {
+                    const pageResponse = await page.goto(
+                      `${edgeOrNodeMiddlewareI18n.url}${pageWithLinksPathname}`,
+                    )
+                    expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
 
-                  await page.hover(`[data-link="${testConfig.selector}"]`)
+                    // wait for hydration to finish before doing client navigation
+                    await expect(page.getByTestId('hydration')).toHaveText('hydrated', {
+                      timeout: 10_000,
+                    })
 
-                  const dataResponse = await dataFetchPromise
+                    await page.evaluate(() => {
+                      // set some value to window to check later if browser did reload and lost this state
+                      ;(window as ExtendedWindow).didReload = false
+                    })
 
-                  expect(dataResponse.ok()).toBe(true)
+                    await page.click(`[data-link="${testConfig.selector}"]`)
+
+                    // wait for page to be rendered
+                    await page.waitForSelector(`[data-page="${testConfig.selector}"]`)
+
+                    // check if browser navigation worked by checking if state was preserved
+                    const browserNavigationWorked =
+                      (await page.evaluate(() => {
+                        return (window as ExtendedWindow).didReload
+                      })) === false
+
+                    // we expect client navigation to work without browser reload
+                    expect(browserNavigationWorked).toBe(true)
+                  })
+                })
+              }
+            })
+            test.describe('with matcher for specific path', () => {
+              const testConfig = {
+                selector: 'test',
+                expectedPathname: '/test',
+                jsonPathMatcher: '/test.json',
+              }
+
+              test('json data prefetch', async ({
+                edgeOrNodeMiddlewareI18nIncludedPaths,
+                page,
+              }) => {
+                const dataFetchPromise = new Promise<Response>((resolve) => {
+                  page.on('response', (response) => {
+                    if (response.url().includes(testConfig.jsonPathMatcher)) {
+                      resolve(response)
+                    }
+                  })
                 })
 
-                test('navigation', async ({ edgeOrNodeMiddlewareI18n, page }) => {
-                  const pageResponse = await page.goto(
-                    `${edgeOrNodeMiddlewareI18n.url}${pageWithLinksPathname}`,
-                  )
-                  expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
+                const pageResponse = await page.goto(
+                  `${edgeOrNodeMiddlewareI18nIncludedPaths.url}${pageWithLinksPathname}`,
+                )
+                expect(await pageResponse?.headerValue('x-runtime')).toEqual(expectedRuntime)
 
-                  // wait for hydration to finish before doing client navigation
-                  await expect(page.getByTestId('hydration')).toHaveText('hydrated', {
-                    timeout: 10_000,
-                  })
+                await page.hover(`[data-link="${testConfig.selector}"]`)
 
-                  await page.evaluate(() => {
-                    // set some value to window to check later if browser did reload and lost this state
-                    ;(window as ExtendedWindow).didReload = false
-                  })
+                const dataResponse = await dataFetchPromise
 
-                  await page.click(`[data-link="${testConfig.selector}"]`)
-
-                  // wait for page to be rendered
-                  await page.waitForSelector(`[data-page="${testConfig.selector}"]`)
-
-                  // check if browser navigation worked by checking if state was preserved
-                  const browserNavigationWorked =
-                    (await page.evaluate(() => {
-                      return (window as ExtendedWindow).didReload
-                    })) === false
-
-                  // we expect client navigation to work without browser reload
-                  expect(browserNavigationWorked).toBe(true)
-                })
+                expect(dataResponse.ok()).toBe(true)
+                expect(dataResponse.headers()['x-hello-from-middleware-res']).toBe('hello')
+                expect(dataResponse.headers()['x-pathname']).toBe(testConfig.expectedPathname)
+                expect(dataResponse.headers()['x-runtime']).toBe(expectedRuntime)
+                expect(dataResponse.headers()['x-locale']).toBe(expectedLocale)
               })
-            }
+
+              test('direct json data fetch', async ({ edgeOrNodeMiddlewareI18nIncludedPaths }) => {
+                const url = `${edgeOrNodeMiddlewareI18nIncludedPaths.url}/_next/data/build-id${localePrefix}${testConfig.jsonPathMatcher}`
+                const response = await fetch(url, {
+                  headers: {
+                    'x-nextjs-data': '1',
+                  },
+                })
+
+                expect(response.headers.get('x-hello-from-middleware-res')).toBe('hello')
+                expect(response.headers.get('x-pathname')).toBe(testConfig.expectedPathname)
+                expect(response.headers.get('x-runtime')).toEqual(expectedRuntime)
+                expect(response.headers.get('x-locale')).toBe(expectedLocale)
+              })
+            })
           })
         }
       })

--- a/tests/fixtures/middleware-included-paths/middleware-node.ts
+++ b/tests/fixtures/middleware-included-paths/middleware-node.ts
@@ -1,0 +1,6 @@
+export { middleware } from './middleware-shared'
+
+export const config = {
+  matcher: ['/test', '/link'],
+  runtime: 'nodejs',
+}

--- a/tests/fixtures/middleware-included-paths/middleware-shared.ts
+++ b/tests/fixtures/middleware-included-paths/middleware-shared.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next()
+
+  response.headers.set('x-hello-from-middleware-res', 'hello')
+  // report Next.js Middleware Runtime (not the execution runtime, but target runtime)
+  // @ts-expect-error EdgeRuntime global not declared
+  response.headers.append('x-runtime', typeof EdgeRuntime !== 'undefined' ? EdgeRuntime : 'node')
+
+  response.headers.set('x-pathname', request.nextUrl.pathname)
+  response.headers.set('x-locale', request.nextUrl.locale)
+
+  return response
+}

--- a/tests/fixtures/middleware-included-paths/middleware.ts
+++ b/tests/fixtures/middleware-included-paths/middleware.ts
@@ -1,0 +1,5 @@
+export { middleware } from './middleware-shared'
+
+export const config = {
+  matcher: ['/test', '/link'],
+}

--- a/tests/fixtures/middleware-included-paths/next-env.d copy.ts
+++ b/tests/fixtures/middleware-included-paths/next-env.d copy.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/tests/fixtures/middleware-included-paths/next-env.d.ts
+++ b/tests/fixtures/middleware-included-paths/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts'
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/tests/fixtures/middleware-included-paths/next.config.js
+++ b/tests/fixtures/middleware-included-paths/next.config.js
@@ -1,0 +1,20 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  output: 'standalone',
+  distDir: process.env.NEXT_DIST_DIR ?? '.next',
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  i18n:
+    process.env.NEXT_I18N == 'true'
+      ? {
+          locales: ['en', 'fr'],
+          defaultLocale: 'en',
+        }
+      : undefined,
+  experimental: {
+    nodeMiddleware: true,
+  },
+  generateBuildId: () => 'build-id',
+  outputFileTracingRoot: __dirname,
+}

--- a/tests/fixtures/middleware-included-paths/package.json
+++ b/tests/fixtures/middleware-included-paths/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "middleware-included-paths",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm run build",
+    "dev": "next dev",
+    "build": "node ../../utils/build-variants.mjs"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.12",
+    "@types/react": "18.2.47",
+    "typescript": "^5.2.2"
+  }
+}

--- a/tests/fixtures/middleware-included-paths/pages/link.tsx
+++ b/tests/fixtures/middleware-included-paths/pages/link.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+
+export default function Page() {
+  const [isHydrated, setIsHydrated] = useState(false)
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
+
+  return (
+    <div>
+      <h1>Link to page that should run middleware</h1>
+      <p>
+        <Link href="/test" data-link="test">
+          getServerSideProps
+        </Link>
+      </p>
+      <pre data-testid="hydration">{isHydrated ? 'hydrated' : 'hydrating'}</pre>
+    </div>
+  )
+}

--- a/tests/fixtures/middleware-included-paths/pages/test.tsx
+++ b/tests/fixtures/middleware-included-paths/pages/test.tsx
@@ -1,0 +1,23 @@
+import type { GetServerSideProps } from 'next'
+
+export default function CatchAll({ data, locale }) {
+  return (
+    <>
+      <div>
+        Data: <span data-testid="data">{data}</span>
+      </div>
+      <div>
+        Locale: <span data-testid="locale">{locale}</span>
+      </div>
+    </>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      data: 'data',
+      locale: locale ?? 'not-i18n',
+    },
+  }
+}

--- a/tests/fixtures/middleware-included-paths/test-variants.json
+++ b/tests/fixtures/middleware-included-paths/test-variants.json
@@ -1,0 +1,21 @@
+{
+  "node-middleware": {
+    "distDir": ".next-node-middleware",
+    "files": {
+      "middleware.ts": "middleware-node.ts"
+    },
+    "test": {
+      "dependencies": {
+        "next": [
+          {
+            "versionConstraint": ">=15.2.6",
+            "canaryOnly": true
+          },
+          {
+            "versionConstraint": ">=15.5.7"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/middleware-included-paths/tsconfig.json
+++ b/tests/fixtures/middleware-included-paths/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tests/prepare.mjs
+++ b/tests/prepare.mjs
@@ -25,6 +25,7 @@ const e2eOnlyFixtures = new Set([
   'dist-dir',
   'dynamic-cms',
   'middleware-i18n-excluded-paths',
+  'middleware-included-paths',
   'middleware-node-runtime-specific',
   'middleware-static-asset-matcher',
   'middleware-subrequest-vuln',

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -256,7 +256,8 @@ async function installRuntime(
       env['YARN_ENABLE_SCRIPTS'] = 'false'
       break
     case 'pnpm':
-      command = `pnpm add file:${relativePathToPackage} ${
+      // we run tests on Node v18 and v20 and latest pnpm requires v22.13
+      command = `corepack pnpm@^10 add file:${relativePathToPackage} ${
         workspaceRelPath ? `--filter ./${workspaceRelPath}` : ''
       } --ignore-scripts`
       break
@@ -518,6 +519,26 @@ export const fixtureFactories = {
   middlewareI18nExcludedPaths: () => createE2EFixture('middleware-i18n-excluded-paths'),
   middlewareI18nExcludedPathsNode: () =>
     createE2EFixture('middleware-i18n-excluded-paths', {
+      buildCommand: getBuildFixtureVariantCommand('node-middleware'),
+      publishDirectory: '.next-node-middleware',
+    }),
+  middlewareI18nIncludedPaths: () =>
+    createE2EFixture('middleware-included-paths', {
+      env: {
+        NEXT_I18N: 'true',
+      },
+    }),
+  middlewareI18nIncludedPathsNode: () =>
+    createE2EFixture('middleware-included-paths', {
+      buildCommand: getBuildFixtureVariantCommand('node-middleware'),
+      publishDirectory: '.next-node-middleware',
+      env: {
+        NEXT_I18N: 'true',
+      },
+    }),
+  middlewareIncludedPaths: () => createE2EFixture('middleware-included-paths'),
+  middlewareIncludedPathsNode: () =>
+    createE2EFixture('middleware-included-paths', {
       buildCommand: getBuildFixtureVariantCommand('node-middleware'),
       publishDirectory: '.next-node-middleware',
     }),

--- a/tests/utils/create-e2e-fixture.ts
+++ b/tests/utils/create-e2e-fixture.ts
@@ -255,12 +255,19 @@ async function installRuntime(
       )}`
       env['YARN_ENABLE_SCRIPTS'] = 'false'
       break
-    case 'pnpm':
-      // we run tests on Node v18 and v20 and latest pnpm requires v22.13
-      command = `corepack pnpm@^10 add file:${relativePathToPackage} ${
+    case 'pnpm': {
+      const rootPkgPath = join(isolatedFixtureRoot, 'package.json')
+      const rootPkg = existsSync(rootPkgPath)
+        ? JSON.parse(await readFile(rootPkgPath, 'utf-8'))
+        : {}
+      // we run tests on Node v18 and v20 and latest pnpm requires v22.13,
+      // so pin to ^10 unless the fixture already declares its own pnpm version
+      const pnpmBin = rootPkg.packageManager?.startsWith('pnpm@') ? 'pnpm' : 'corepack pnpm@^10'
+      command = `${pnpmBin} add file:${relativePathToPackage} ${
         workspaceRelPath ? `--filter ./${workspaceRelPath}` : ''
       } --ignore-scripts`
       break
+    }
     case 'bun':
       command = `bun install ./${packageName}`
       break


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

<!-- Provide a brief summary of the change. -->

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added fixture and test for cases when "allow list" paths are used for middleware/proxy matching

