### PR TITLE
fix: vary RSC responses by auth inputs

### DIFF
--- a/src/run/headers.test.ts
+++ b/src/run/headers.test.ts
@@ -60,6 +60,42 @@ describe('headers', () => {
         )
       })
 
+      test('with RSC request cookies added to avoid sharing user-specific flight data', () => {
+        const headers = new Headers()
+        const request = new Request(defaultUrl, {
+          headers: {
+            RSC: '1',
+            Cookie: 'session=user-a; theme=dark',
+          },
+        })
+        vi.spyOn(headers, 'set')
+
+        setVaryHeaders(headers, request, defaultConfig)
+
+        expect(headers.set).toBeCalledWith(
+          'netlify-vary',
+          'query=__nextDataReq|_rsc,header=x-nextjs-data|x-next-debug-logging|next-router-prefetch|next-router-segment-prefetch|next-router-state-tree|next-url|rsc,cookie=__prerender_bypass|__next_preview_data|session|theme',
+        )
+      })
+
+      test('with RSC request authorization added to avoid sharing authenticated flight data', () => {
+        const headers = new Headers()
+        const request = new Request(defaultUrl, {
+          headers: {
+            RSC: '1',
+            Authorization: 'Bearer user-a',
+          },
+        })
+        vi.spyOn(headers, 'set')
+
+        setVaryHeaders(headers, request, defaultConfig)
+
+        expect(headers.set).toBeCalledWith(
+          'netlify-vary',
+          'query=__nextDataReq|_rsc,header=x-nextjs-data|x-next-debug-logging|next-router-prefetch|next-router-segment-prefetch|next-router-state-tree|next-url|rsc|authorization,cookie=__prerender_bypass|__next_preview_data',
+        )
+      })
+
       test('with no languages if i18n config has localeDetection disabled', () => {
         const headers = new Headers()
         const request = new Request(defaultUrl)

--- a/src/run/headers.ts
+++ b/src/run/headers.ts
@@ -76,6 +76,13 @@ const omitHeaderValues = (header: string, values: string[]): string => {
   return filteredValues.join(', ')
 }
 
+const getCookieNames = (cookieHeader: string): string[] => {
+  return cookieHeader
+    .split(';')
+    .map((cookie) => cookie.trim().split('=')[0]?.trim())
+    .filter((cookieName): cookieName is string => Boolean(cookieName))
+}
+
 /**
  * Ensure the Netlify CDN varies on things that Next.js varies on,
  * e.g. i18n, preview mode, etc.
@@ -116,6 +123,20 @@ export const setVaryHeaders = (
   if (locales.length > 1 && (path === '/' || path === basePath)) {
     netlifyVaryValues.language.push(...locales)
     netlifyVaryValues.cookie.push(`NEXT_LOCALE`)
+  }
+
+  if (request.headers.get('rsc') === '1') {
+    const cookie = request.headers.get('cookie')
+    if (cookie) {
+      // Auth/session cookies can affect RSC flight payloads. When a RSC response
+      // is made cacheable (for example by middleware or page cache-control), make
+      // sure distinct cookie values do not share the same Netlify cache object.
+      netlifyVaryValues.cookie.push(...getCookieNames(cookie))
+    }
+
+    if (request.headers.has('authorization')) {
+      netlifyVaryValues.header.push('authorization')
+    }
   }
 
   const userNetlifyVary = headers.get('netlify-vary')


### PR DESCRIPTION
## Summary

- Adds request cookie names to `Netlify-Vary` for RSC/flight requests so cacheable RSC payloads vary by session/auth cookies instead of sharing one cache object across users.
- Adds `authorization` to the `Netlify-Vary` header list for RSC requests that include an `Authorization` header.
- Adds unit coverage for authenticated RSC vary behavior.

## Why

RSC/flight payloads can contain user-specific data when an App Router page reads `cookies()`/auth state. If a page or middleware makes that RSC response cacheable, the existing default `Netlify-Vary` only varies on Next/RSC routing headers and preview cookies. That can allow a cached `text/x-component` payload for one authenticated user to be reused for another user with the same RSC route/cache key.

This is a defensive hardening layer: for RSC requests that arrive with cookies or authorization, include those auth inputs in the Netlify cache key.

## Test plan

- `npm run test:unit -- src/run/headers.test.ts`
- `npm run lint -- --no-cache src/run/headers.ts src/run/headers.test.ts`
- `npm run typecheck`
- `npm run build`
