### PR TITLE
fix(v4): skip RSC data rewrites for authenticated requests

### DIFF
--- a/packages/runtime/src/templates/edge-shared/rsc-data.test.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from 'https://deno.land/std@0.167.0/testing/asserts.ts'
+import { describe, it } from 'https://deno.land/std@0.167.0/testing/bdd.ts'
+import { getRscDataRouter, PrerenderManifest } from './rsc-data.ts'
+
+const manifest: PrerenderManifest = {
+  version: 3,
+  routes: {},
+  dynamicRoutes: {
+    '/[...slug]': {
+      routeRegex: '^/(.+?)(?:/)?$',
+      fallback: null,
+      dataRoute: '/[...slug].rsc',
+      dataRouteRegex: '^/(.+?)\\.rsc$',
+    },
+  },
+  notFoundRoutes: [],
+}
+
+const createContext = () => {
+  let rewrittenTo: string | undefined
+
+  return {
+    context: {
+      rewrite: (target: string) => {
+        rewrittenTo = target
+        return new Response('rewritten')
+      },
+    },
+    get rewrittenTo() {
+      return rewrittenTo
+    },
+  }
+}
+
+describe('getRscDataRouter', () => {
+  it('rewrites anonymous RSC requests that match prerendered dynamic routes', () => {
+    const router = getRscDataRouter(manifest)
+    const rewriteContext = createContext()
+
+    const response = router(
+      new Request('https://example.netlify.app/dashboard', {
+        headers: {
+          RSC: '1',
+        },
+      }),
+      rewriteContext.context as never,
+    )
+
+    assertEquals(response instanceof Response, true)
+    assertEquals(rewriteContext.rewrittenTo, '/dashboard.rsc')
+  })
+
+  it('does not rewrite RSC requests with cookies', () => {
+    const router = getRscDataRouter(manifest)
+    const rewriteContext = createContext()
+
+    const response = router(
+      new Request('https://example.netlify.app/dashboard', {
+        headers: {
+          RSC: '1',
+          Cookie: 'user=A',
+        },
+      }),
+      rewriteContext.context as never,
+    )
+
+    assertEquals(response, void 0)
+    assertEquals(rewriteContext.rewrittenTo, void 0)
+  })
+
+  it('does not rewrite RSC requests with authorization', () => {
+    const router = getRscDataRouter(manifest)
+    const rewriteContext = createContext()
+
+    const response = router(
+      new Request('https://example.netlify.app/dashboard', {
+        headers: {
+          RSC: '1',
+          Authorization: 'Bearer user-a',
+        },
+      }),
+      rewriteContext.context as never,
+    )
+
+    assertEquals(response, void 0)
+    assertEquals(rewriteContext.rewrittenTo, void 0)
+  })
+})

--- a/packages/runtime/src/templates/edge-shared/rsc-data.ts
+++ b/packages/runtime/src/templates/edge-shared/rsc-data.ts
@@ -64,9 +64,18 @@ export const getRscDataRouter = ({ routes: staticRoutes, dynamicRoutes }: Preren
     const debug = request.headers.has('x-next-debug-logging')
     const log = debug ? (...args: unknown[]) => console.log(...args) : noop
     const url = new URL(request.url)
-    // If this is a static RSC request, rewrite to the data route
+    // If this is a static RSC request, rewrite to the data route.
+    // Authenticated RSC requests can contain user-specific flight payloads. If
+    // a broad static catch-all route matches a dynamic page, rewriting an
+    // authenticated request to a cacheable `.rsc` route can allow the first
+    // user's payload to be reused for later users by the CDN/ODB cache. Let
+    // authenticated requests continue to the origin route instead.
     if (request.headers.get('rsc') === '1') {
       log('Is rsc request')
+      if (request.headers.has('cookie') || request.headers.has('authorization')) {
+        log('Skipping RSC data rewrite for authenticated request')
+        return
+      }
       if (matchesRscRoute(url.pathname)) {
         request.headers.set('x-rsc-route', url.pathname)
         const target = rscifyPath(url.pathname)


### PR DESCRIPTION
## Summary

- Updates the legacy Runtime v4 `rsc-data` edge router to skip `.rsc` data-route rewrites for RSC requests that include `Cookie` or `Authorization` headers.
- Keeps anonymous/static RSC requests on the existing rewrite path.
- Adds Deno tests for anonymous rewrite behavior and authenticated bypass behavior.

## Why

Runtime v4 generates an `rsc-data` edge function that rewrites App Router RSC requests matching prerendered static/dynamic routes to `.rsc` data routes. A broad App Router SSG catch-all route can match a concrete dynamic authenticated page such as `/dashboard`, causing an authenticated RSC request to be rewritten to a cacheable `.rsc` path.

If that RSC payload contains user-specific data and is later cached by the CDN/ODB path, subsequent users can receive the first user's `text/x-component` payload. Authenticated RSC requests should therefore continue to the origin route instead of being rewritten to static RSC data routes.

Runtime v5 does not reproduce this issue in the controlled repro; this patch is scoped to the legacy Runtime v4 RSC data-routing path.

## Demo repro

Patched Runtime v4 deployable demo repo:

https://github.com/dunfe/netlify-next-v4-patched-cache-repro

This repo keeps the same vulnerable app shape as the original repro:

- `next@14.2.35`
- App Router SSG catch-all: `● /[...slug]`
- Dynamic authenticated dashboard: `ƒ /dashboard`
- `SIMULATE_CONTENTFUL_FAILURE=1`
- Middleware still sets cacheable headers for `/dashboard`

The only intended change is that it installs a locally packed patched Runtime v4 plugin tarball:

```json
"@netlify/plugin-nextjs": "file:vendor/netlify-plugin-nextjs-4.41.6-rsc-auth-rewrite-fix.tgz"
```

Local verification for the demo repo:

```txt
Using Next.js Runtime - v4.41.6

Functions:
- ___netlify-handler
- ___netlify-odb-handler
- _ipx

Edge Functions:
- next_middleware
- rsc-data
```

The generated Runtime v4 `rsc-data` edge function contains the patch:

```ts
if (request.headers.has('cookie') || request.headers.has('authorization')) {
  return
}
```

Expected behavior for the patched demo:

- User A's RSC request to `/dashboard` returns `User A`.
- User B's RSC request to `/dashboard` returns `User B`.
- User B should not receive User A's cached `text/x-component` payload.

Original vulnerable repro and root-cause report:

https://github.com/dunfe/netlify-next-first-user-cache-repro
