### PR TITLE
test: adjust assertion version gates

### DIFF
--- a/tests/e2e/skew-protection.test.ts
+++ b/tests/e2e/skew-protection.test.ts
@@ -692,12 +692,16 @@ test.describe('Skew Protection', () => {
 
       expect(params.get('url')).toBe('/local-image.png')
 
-      // Whether public/ images get a deployment id changed in Next.js 16.1.0: the loader used to
-      // only append `&dpl=` for /_next/static/media images (which are content hashed, so build
-      // specific), and now appends it for every local image. Unlike a statically imported image,
-      // a public/ one has the same URL in both deploys and only the content differs, so the
-      // deployment id is the only thing that can scope the request.
-      if (nextVersionSatisfies('>=16.1.0')) {
+      // Unlike a statically imported image, a public/ one has the same URL in both deploys and
+      // only the content differs, so the deployment id is the only thing that can scope the
+      // request - and whether next/image sends one has flip-flopped:
+      //   <15.1.0        `&dpl=` appended to every image, remote ones included
+      //                  https://github.com/vercel/next.js/pull/50470 (added in 13.4.5)
+      //   15.1.0-16.0.x  narrowed to /_next/static/media only, i.e. static imports
+      //                  https://github.com/vercel/next.js/pull/73184
+      //   >=16.1.0       widened back out to every local image
+      //                  https://github.com/vercel/next.js/pull/86485
+      if (nextVersionSatisfies('<15.1.0 || >=16.1.0')) {
         expect(params.get('dpl')).toBe(deploymentId)
 
         await expectImageToBeFromVariant(


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Follow up to https://github.com/opennextjs/opennextjs-netlify/pull/3547 - version gate was not correct as Next.js was changing logic over-time there and was not caught earlier ( see https://github.com/opennextjs/opennextjs-netlify/pull/3548 failing on older Next.js versions)

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

<!-- Did you add tests? How did you test this change? -->

You can test this change yourself like so:

1. TODO

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
