### PR TITLE
test: update next-16-tag-revalidation fixture

### DIFF
--- a/tests/fixtures/next-16-tag-revalidation/next.config.js
+++ b/tests/fixtures/next-16-tag-revalidation/next.config.js
@@ -6,8 +6,11 @@ const nextConfig = {
     cacheLife: {
       testCacheLife: {
         stale: 0,
-        revalidate: 365 * 60 * 60 * 24, // 1 year
-        expire: 5, // 5 seconds to test expiration
+        // revalidate has to be lower than expire to pass config validation.
+        // We only use this profile to test on-demand revalidation which only uses `expire` value
+        revalidate: 1,
+        // 5 seconds to test expiration
+        expire: 5,
       },
     },
   },


### PR DESCRIPTION
## Description

Just updating a test fixture's `next.config.js` to pass recently added validation. Doesn't affect the tests - see inline comment