### PR TITLE
fix: don't abort cacheComponents prerenders when OTel spans are created

### DIFF
--- a/src/run/handlers/server.ts
+++ b/src/run/handlers/server.ts
@@ -33,7 +33,47 @@ setupWaitUntil()
 
 const nextImportPromise = import('../next.cjs')
 
-let nextHandler: WorkerRequestHandler
+type NextModule = Awaited<typeof nextImportPromise>
+
+type InitializedNextServer = {
+  nextHandler: WorkerRequestHandler
+  ensureOtelTracerPatchedForCacheComponents: NextModule['ensureOtelTracerPatchedForCacheComponents']
+}
+
+let initializedNextServer: InitializedNextServer | undefined
+let nextServerPromise: Promise<InitializedNextServer> | undefined
+
+const initializeNextServer = (
+  request: Request,
+  tracer: ReturnType<typeof getTracer>,
+): Promise<InitializedNextServer> => {
+  if (!nextServerPromise) {
+    nextServerPromise = withActiveSpan(tracer, 'initialize next server', async () => {
+      const { getMockedRequestHandler, ensureOtelTracerPatchedForCacheComponents } =
+        await nextImportPromise
+      const url = new URL(request.url)
+
+      const nextHandler = await getMockedRequestHandler(nextConfig, {
+        port: Number(url.port) || 443,
+        hostname: url.hostname,
+        dir: process.cwd(),
+        isDev: false,
+      })
+
+      return { nextHandler, ensureOtelTracerPatchedForCacheComponents }
+    })
+      .then((server) => {
+        initializedNextServer = server
+        return server
+      })
+      .catch((error) => {
+        nextServerPromise = undefined
+        throw error
+      })
+  }
+
+  return nextServerPromise
+}
 
 /**
  * When Next.js proxies requests externally, it writes the response back as-is.
@@ -66,19 +106,12 @@ export default async (
 ) => {
   const tracer = getTracer()
 
-  if (!nextHandler) {
-    await withActiveSpan(tracer, 'initialize next server', async () => {
-      const { getMockedRequestHandler } = await nextImportPromise
-      const url = new URL(request.url)
+  const { nextHandler, ensureOtelTracerPatchedForCacheComponents } =
+    initializedNextServer ?? (await initializeNextServer(request, tracer))
 
-      nextHandler = await getMockedRequestHandler(nextConfig, {
-        port: Number(url.port) || 443,
-        hostname: url.hostname,
-        dir: process.cwd(),
-        isDev: false,
-      })
-    })
-  }
+  // Per request, not during initialization: the platform only registers its OpenTelemetry
+  // SDK once a traced request arrives. See the note on the function itself.
+  ensureOtelTracerPatchedForCacheComponents(topLevelSpan)
 
   return await withActiveSpan(tracer, 'generate response', async (span) => {
     const { req, res } = toReqRes(request)

--- a/src/run/next.cts
+++ b/src/run/next.cts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import fs from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
 
+import type { Span } from '@netlify/otel/opentelemetry'
 // @ts-expect-error no types installed
 import { patchFs } from 'fs-monkey'
 
@@ -9,7 +10,7 @@ import { HtmlBlob } from '../shared/blob-types.cjs'
 
 import type { NextConfigForMultipleVersions } from './config.js'
 import { getRequestContext } from './handlers/request-context.cjs'
-import { getTracer, withActiveSpan } from './handlers/tracer.cjs'
+import { getTracer, recordWarning, withActiveSpan } from './handlers/tracer.cjs'
 import { getMemoizedKeyValueStoreBackedByRegionalBlobStore } from './storage/storage.cjs'
 
 // https://github.com/vercel/next.js/pull/68193/files#diff-37243d614f1f5d3f7ea50bbf2af263f6b1a9a4f70e84427977781e07b02f57f1R49
@@ -151,4 +152,77 @@ export async function getMockedRequestHandler(
     // see https://github.com/vercel/next.js/commit/08e7410f15706379994b54c3195d674909a8d533#diff-37243d614f1f5d3f7ea50bbf2af263f6b1a9a4f70e84427977781e07b02f57f1R742
     return Array.isArray(requestHandlers) ? requestHandlers[0] : requestHandlers.requestHandler
   })
+}
+
+let cacheComponentsTracerPatchState: 'pending' | 'patched' | 'unavailable' = 'pending'
+
+/**
+ * Next.js only installs its Cache Components tracer patch when the application itself has an
+ * `instrumentation.ts` exporting `register` - `afterRegistration()` is called from there and
+ * nowhere else:
+ * https://github.com/vercel/next.js/blob/9480f7f9ffdc271014d959e7b10d681882eaabb5/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts#L56-L59
+ *
+ * Our Functions bootstrap registers an OpenTelemetry SDK outside that hook, so on sites with no
+ * `instrumentation.ts` the tracer is left unpatched. An unpatched tracer generates span ids with
+ * OpenTelemetry's `RandomIdGenerator`, which uses `Math.random()`:
+ * https://github.com/open-telemetry/opentelemetry-js/blob/76fa6b509e2b48d9cbee31cb37a2efc61dc4d384/packages/sdk-trace/src/platform/node/RandomIdGenerator.ts#L31
+ *
+ * With `cacheComponents` enabled Next patches `Math.random` to count as synchronous platform IO,
+ * which aborts the surrounding prerender:
+ * https://github.com/vercel/next.js/blob/9480f7f9ffdc271014d959e7b10d681882eaabb5/packages/next/src/server/node-environment-extensions/random.tsx#L14-L15
+ *
+ * The failure is silent - the runtime-prefetch payload that seeds the client segment cache is
+ * dropped from the initial HTML, so navigations refetch content that should already have been
+ * seeded.
+ *
+ * Calling `afterRegistration()` ourselves fixes it. It patches whichever provider is registered
+ * on `@opentelemetry/api`, resolving that package from the app and falling back to Next's own
+ * bundled copy:
+ * https://github.com/vercel/next.js/blob/9480f7f9ffdc271014d959e7b10d681882eaabb5/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts#L52-L59
+ *
+ * That fallback is what makes this work for us. We bundle `@opentelemetry/api` into the
+ * bootstrap, so the app cannot resolve one and Next uses its compiled copy - yet both reach the
+ * same `ProxyTracerProvider`, because the API keeps its global registration on `globalThis`
+ * under `Symbol.for('opentelemetry.js.api.<major>')`, shared by every copy of the package on the
+ * same major version:
+ * https://github.com/open-telemetry/opentelemetry-js/blob/76fa6b509e2b48d9cbee31cb37a2efc61dc4d384/api/src/internal/global-utils.ts#L15
+ *
+ * It has to run from a request though: after Next's `node-environment` is loaded (it pulls in
+ * `work-unit-async-storage-instance`, which throws if `AsyncLocalStorage` isn't set up yet) and
+ * after the SDK has registered, which the bootstrap only does once a traced request arrives. On
+ * a warm lambda that can be many requests in, hence the repeated check rather than a one-shot
+ * call at startup.
+ *
+ * Remove once Next.js calls `afterRegistration()` unconditionally.
+ */
+export function ensureOtelTracerPatchedForCacheComponents(span?: Span) {
+  if (cacheComponentsTracerPatchState !== 'pending') {
+    return
+  }
+
+  // Only returns a tracer once a provider is registered, so this is the signal that there
+  // is something to patch.
+  if (!getTracer()) {
+    return
+  }
+
+  try {
+    // Runtime lookup: the module only exists in Next.js versions that ship Cache Components.
+    const extensionsPath = 'next/dist/server/lib/router-utils/instrumentation-node-extensions.js'
+    // eslint-disable-next-line n/global-require, @typescript-eslint/no-var-requires, import/no-dynamic-require
+    const { afterRegistration } = require(extensionsPath)
+    afterRegistration()
+    cacheComponentsTracerPatchState = 'patched'
+  } catch (error) {
+    cacheComponentsTracerPatchState = 'unavailable'
+
+    // A missing module just means a Next.js version predating the extension - nothing to
+    // patch, nothing worth reporting. Anything else is unexpected.
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'MODULE_NOT_FOUND') {
+      recordWarning(
+        new Error('Failed to patch OpenTelemetry tracer for Cache Components', { cause: error }),
+        span,
+      )
+    }
+  }
 }

--- a/tests/fixtures/ppr/app/runtime-prefetchable/page.js
+++ b/tests/fixtures/ppr/app/runtime-prefetchable/page.js
@@ -1,0 +1,28 @@
+import { cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+
+export const prefetch = 'partial'
+
+export default async function Page({ searchParams }) {
+  return (
+    <main>
+      <CachedContent />
+      <Suspense fallback={<p>Loading search params...</p>}>
+        <SearchParamsContent searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function CachedContent() {
+  'use cache'
+  cacheLife({ stale: 120 })
+  return <p id="cached-content">Cached content ({new Date().toISOString()})</p>
+}
+
+async function SearchParamsContent({ searchParams }) {
+  'use cache: private'
+  cacheLife({ stale: 30 })
+  const { q } = await searchParams
+  return <p>Search params: {q ?? 'none'}</p>
+}

--- a/tests/fixtures/ppr/next.config.js
+++ b/tests/fixtures/ppr/next.config.js
@@ -1,13 +1,29 @@
 const { satisfies } = require('semver')
 
+const nextVersion = require('next/package.json').version
+const isAtLeast = (version) => satisfies(nextVersion, `>=${version}`, { includePrerelease: true })
+
 // https://github.com/vercel/next.js/pull/84280
-const pprConfigHardDeprecated = satisfies(
-  require('next/package.json').version,
-  '>=15.6.0-canary.58',
-  {
-    includePrerelease: true,
-  },
-)
+const pprConfigHardDeprecated = isAtLeast('15.6.0-canary.58')
+
+// https://github.com/vercel/next.js/pull/85035 moved the flag out of `experimental`. Setting
+// it in the old place is silently ignored, so the placement has to follow the version.
+const cacheComponentsIsTopLevel = isAtLeast('16.0.0-canary.14')
+
+// https://github.com/vercel/next.js/pull/94448
+// `export const prefetch = 'partial'` only produces a runtime prefetch payload when cached
+// navigations are enabled.
+const supportsCachedNavigations = isAtLeast('16.2.0-canary.83')
+
+const experimental = {}
+if (!pprConfigHardDeprecated) {
+  experimental.ppr = true
+} else if (!cacheComponentsIsTopLevel) {
+  experimental.cacheComponents = true
+}
+if (supportsCachedNavigations) {
+  experimental.cachedNavigations = true
+}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -15,13 +31,8 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  experimental: pprConfigHardDeprecated
-    ? {
-        cacheComponents: true,
-      }
-    : {
-        ppr: true,
-      },
+  ...(cacheComponentsIsTopLevel ? { cacheComponents: true } : {}),
+  experimental,
   outputFileTracingRoot: __dirname,
 }
 

--- a/tests/integration/ppr.test.ts
+++ b/tests/integration/ppr.test.ts
@@ -49,6 +49,7 @@ test.skipIf(
       shouldHaveAppRouterNotFoundInPrerenderManifest() ? '/_not-found' : undefined,
       '/dynamic-params/[id]',
       '/index',
+      '/runtime-prefetchable',
       '/static-params/1',
       '/static-params/2',
       '/static-params/[id]',
@@ -74,4 +75,10 @@ test.skipIf(
   expect(res3.statusCode).toBe(200)
   // on this page, the `await params` is in a Suspense boundary
   expect(load(res3.body)('body').text()).toContain('loading...')
+
+  const res4 = await invokeFunction(ctx, { url: '/runtime-prefetchable' })
+  expect(res4.statusCode).toBe(200)
+  // this page renders `use cache: private` content, which resolves on the server rather
+  // than leaving its Suspense fallback in the response
+  expect(load(res4.body)('body').text()).toContain('Search params: none')
 })

--- a/tests/integration/ppr.test.ts
+++ b/tests/integration/ppr.test.ts
@@ -1,10 +1,16 @@
 import { load } from 'cheerio'
 import { getLogger } from 'lambda-local'
+import { fileURLToPath } from 'node:url'
 import { v4 } from 'uuid'
-import { beforeEach, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { type FixtureTestContext } from '../utils/contexts.js'
-import { createFixture, invokeFunction, runPlugin } from '../utils/fixture.js'
+import {
+  createFixture,
+  invokeFunction,
+  loadSandboxedFunction,
+  runPlugin,
+} from '../utils/fixture.js'
 import {
   decodeBlobKey,
   generateRandomObjectID,
@@ -12,6 +18,7 @@ import {
   startMockBlobStore,
 } from '../utils/helpers.js'
 import {
+  hasPartialPrefetching,
   isExperimentalPPRHardDeprecated,
   nextVersionSatisfies,
   shouldHaveAppRouterGlobalErrorInPrerenderManifest,
@@ -81,4 +88,53 @@ test.skipIf(
   // this page renders `use cache: private` content, which resolves on the server rather
   // than leaving its Suspense fallback in the response
   expect(load(res4.body)('body').text()).toContain('Search params: none')
+})
+
+/** Reassembles the RSC flight payload that Next.js inlines into the initial HTML. */
+function getInlinedFlightPayload(html: string): string {
+  let flight = ''
+  for (const match of html.matchAll(/self\.__next_f\.push\(\[1,\s*("(?:[^"\\]|\\.)*")\]\)/g)) {
+    flight += JSON.parse(match[1])
+  }
+
+  return flight
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+/**
+ * Registers an OpenTelemetry SDK globally, outside the application's `instrumentation.ts`
+ * hook, exactly like Netlify's Functions bootstrap does.
+ */
+const OTEL_BOOTSTRAP = fileURLToPath(new URL('../utils/otel-bootstrap.cjs', import.meta.url))
+
+describe('Cache Components + OpenTelemetry', () => {
+  // When an OpenTelemetry SDK is registered, generating a span id calls `Math.random()`, which
+  // Next.js treats as synchronous platform IO while prerendering and aborts the runtime
+  // prerender. The abort is swallowed, so the page still renders - it just silently loses the
+  // runtime prefetch payload that seeds the client segment cache.
+  test.skipIf(!hasPartialPrefetching())<FixtureTestContext>(
+    'runtime prefetch payload survives when an OpenTelemetry SDK is registered',
+    async (ctx) => {
+      await createFixture('ppr', ctx)
+      await runPlugin(ctx)
+
+      const { invokeFunction: invokeWithOtel } = await loadSandboxedFunction(ctx, {
+        env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
+      })
+
+      const response = await invokeWithOtel({ url: '/runtime-prefetchable' })
+
+      expect(response.statusCode).toBe(200)
+      expect(
+        countOccurrences(getInlinedFlightPayload(response.body), 'cached-content'),
+        "'cached-content' to appear twice in the flight payload - once for the rendered page " +
+          'portion and once for the runtime prefetch portion that seeds the client segment ' +
+          'cache. Getting 1 means the runtime prerender aborted and only the rendered page ' +
+          'portion was emitted',
+      ).toBe(2)
+    },
+  )
 })

--- a/tests/integration/ppr.test.ts
+++ b/tests/integration/ppr.test.ts
@@ -1,9 +1,12 @@
 import { load } from 'cheerio'
+import { execa } from 'execa'
 import { getLogger } from 'lambda-local'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { v4 } from 'uuid'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { SERVER_HANDLER_NAME } from '../../src/build/plugin-context.js'
 import { type FixtureTestContext } from '../utils/contexts.js'
 import {
   createFixture,
@@ -18,6 +21,7 @@ import {
   startMockBlobStore,
 } from '../utils/helpers.js'
 import {
+  hasCacheComponentsTracerPatch,
   hasPartialPrefetching,
   isExperimentalPPRHardDeprecated,
   nextVersionSatisfies,
@@ -111,10 +115,60 @@ function countOccurrences(haystack: string, needle: string): number {
 const OTEL_BOOTSTRAP = fileURLToPath(new URL('../utils/otel-bootstrap.cjs', import.meta.url))
 
 describe('Cache Components + OpenTelemetry', () => {
-  // When an OpenTelemetry SDK is registered, generating a span id calls `Math.random()`, which
-  // Next.js treats as synchronous platform IO while prerendering and aborts the runtime
-  // prerender. The abort is swallowed, so the page still renders - it just silently loses the
-  // runtime prefetch payload that seeds the client segment cache.
+  // Next.js only installs its Cache Components tracer patch when the application has an
+  // `instrumentation.ts` exporting `register`, so an SDK registered by our Functions
+  // bootstrap is left unpatched. `ensureOtelTracerPatchedForCacheComponents` works around
+  // that by calling Next.js' own `afterRegistration()` - see the note on it in
+  // `src/run/next.cts`.
+  //
+  // That reaches into a private Next.js module, so if Next.js ever moves or reworks it we
+  // would silently stop patching. This calls our own function inside the built server handler
+  // - where `next` resolves to the version under test - and asserts it still has an effect.
+  test.skipIf(!hasCacheComponentsTracerPatch())<FixtureTestContext>(
+    'our tracer patching still takes effect',
+    async (ctx) => {
+      await createFixture('ppr', ctx)
+      await runPlugin(ctx)
+
+      const probe = `
+        // Resolve @opentelemetry/api the way Next.js' extension does, so we read the provider
+        // back from the same copy it patches. The API's compatibility check is asymmetric, so
+        // going through a different copy can hand back a different provider.
+        let api
+        try {
+          api = require('@opentelemetry/api')
+        } catch {
+          api = require('next/dist/compiled/@opentelemetry/api')
+        }
+        const getTracerBeforePatch = api.trace.getTracerProvider().getTracer
+
+        const { ensureOtelTracerPatchedForCacheComponents } = require('./.netlify/dist/run/next.cjs')
+        ensureOtelTracerPatchedForCacheComponents()
+
+        if (api.trace.getTracerProvider().getTracer === getTracerBeforePatch) {
+          throw new Error(
+            'ensureOtelTracerPatchedForCacheComponents() no longer patches the registered tracer provider',
+          )
+        }
+      `
+
+      // Runs in a child process because the runtime patches process globals (`Math.random`,
+      // `Date`, `console`) that other tests would otherwise inherit. The SDK is registered by
+      // a preload, so it is in place before the runtime is imported - `@netlify/otel` keeps
+      // its global tracer on a plain `globalThis` key, so the copy in the bundle finds it.
+      const { exitCode } = await execa('node', ['-e', probe], {
+        cwd: join(ctx.functionDist, SERVER_HANDLER_NAME),
+        env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
+      })
+
+      expect(exitCode).toBe(0)
+    },
+  )
+
+  // ...and this is what that patch buys us. Without it, generating a span id calls
+  // `Math.random()`, which Next.js treats as synchronous platform IO while prerendering and
+  // aborts the runtime prerender. The abort is swallowed, so the page still renders - it just
+  // silently loses the runtime prefetch payload that seeds the client segment cache.
   test.skipIf(!hasPartialPrefetching())<FixtureTestContext>(
     'runtime prefetch payload survives when an OpenTelemetry SDK is registered',
     async (ctx) => {

--- a/tests/integration/ppr.test.ts
+++ b/tests/integration/ppr.test.ts
@@ -32,68 +32,6 @@ import {
 // Disable the verbose logging of the lambda-local runtime
 getLogger().level = 'alert'
 
-beforeEach<FixtureTestContext>(async (ctx) => {
-  // set for each test a new deployID and siteID
-  ctx.deployID = generateRandomObjectID()
-  ctx.siteID = v4()
-  vi.stubEnv('SITE_ID', ctx.siteID)
-  vi.stubEnv('DEPLOY_ID', ctx.deployID)
-  // hide debug logs in tests
-  vi.spyOn(console, 'debug').mockImplementation(() => {})
-
-  await startMockBlobStore(ctx)
-})
-
-test.skipIf(
-  process.env.NEXT_VERSION !== 'canary' && nextVersionSatisfies('<16.0.0'),
-)<FixtureTestContext>('Test that a simple next app with PPR is working', async (ctx) => {
-  await createFixture('ppr', ctx)
-  await runPlugin(ctx)
-
-  // check if the blob entries were successfully set on the build plugin
-  const blobEntries = await getBlobEntries(ctx)
-  expect(blobEntries.map(({ key }) => decodeBlobKey(key)).sort()).toEqual(
-    [
-      shouldHaveAppRouterNotFoundInPrerenderManifest() ? undefined : '/404',
-      isExperimentalPPRHardDeprecated() ? undefined : '/static-params/[id]',
-      shouldHaveAppRouterGlobalErrorInPrerenderManifest() ? '/_global-error' : undefined,
-      shouldHaveAppRouterNotFoundInPrerenderManifest() ? '/_not-found' : undefined,
-      '/dynamic-params/[id]',
-      '/index',
-      '/runtime-prefetchable',
-      '/static-params/1',
-      '/static-params/2',
-      '/static-params/[id]',
-      '404.html',
-      '500.html',
-    ].filter(Boolean),
-  )
-
-  // test the function call
-  const home = await invokeFunction(ctx)
-  expect(home.statusCode).toBe(200)
-  expect(load(home.body)('h1').text()).toBe('Home')
-
-  const res1 = await invokeFunction(ctx, { url: '/static-params/1' })
-  expect(res1.statusCode).toBe(200)
-  expect(load(res1.body)('h1').text()).toBe('Dynamic Page (static params): 1')
-
-  const res2 = await invokeFunction(ctx, { url: '/static-params/3' })
-  expect(res2.statusCode).toBe(200)
-  expect(load(res2.body)('h1').text()).toBe('Dynamic Page (static params): 3')
-
-  const res3 = await invokeFunction(ctx, { url: '/dynamic-params/123' })
-  expect(res3.statusCode).toBe(200)
-  // on this page, the `await params` is in a Suspense boundary
-  expect(load(res3.body)('body').text()).toContain('loading...')
-
-  const res4 = await invokeFunction(ctx, { url: '/runtime-prefetchable' })
-  expect(res4.statusCode).toBe(200)
-  // this page renders `use cache: private` content, which resolves on the server rather
-  // than leaving its Suspense fallback in the response
-  expect(load(res4.body)('body').text()).toContain('Search params: none')
-})
-
 /** Reassembles the RSC flight payload that Next.js inlines into the initial HTML. */
 function getInlinedFlightPayload(html: string): string {
   let flight = ''
@@ -114,23 +52,90 @@ function countOccurrences(haystack: string, needle: string): number {
  */
 const OTEL_BOOTSTRAP = fileURLToPath(new URL('../utils/otel-bootstrap.cjs', import.meta.url))
 
-describe('Cache Components + OpenTelemetry', () => {
-  // Next.js only installs its Cache Components tracer patch when the application has an
-  // `instrumentation.ts` exporting `register`, so an SDK registered by our Functions
-  // bootstrap is left unpatched. `ensureOtelTracerPatchedForCacheComponents` works around
-  // that by calling Next.js' own `afterRegistration()` - see the note on it in
-  // `src/run/next.cts`.
-  //
-  // That reaches into a private Next.js module, so if Next.js ever moves or reworks it we
-  // would silently stop patching. This calls our own function inside the built server handler
-  // - where `next` resolves to the version under test - and asserts it still has an effect.
-  test.skipIf(!hasCacheComponentsTracerPatch())<FixtureTestContext>(
-    'our tracer patching still takes effect',
-    async (ctx) => {
+// The `ppr` fixture declares `test.dependencies.next: "canary || >=16.0.0"`, so on older
+// releases it is never installed or built. Every test here needs that build to assert
+// against, so skip the whole file rather than fail on a missing one.
+describe.skipIf(process.env.NEXT_VERSION !== 'canary' && nextVersionSatisfies('<16.0.0'))(
+  'PPR',
+  () => {
+    beforeEach<FixtureTestContext>(async (ctx) => {
+      // set for each test a new deployID and siteID
+      ctx.deployID = generateRandomObjectID()
+      ctx.siteID = v4()
+      vi.stubEnv('SITE_ID', ctx.siteID)
+      vi.stubEnv('DEPLOY_ID', ctx.deployID)
+      // hide debug logs in tests
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+      await startMockBlobStore(ctx)
+    })
+
+    test<FixtureTestContext>('Test that a simple next app with PPR is working', async (ctx) => {
       await createFixture('ppr', ctx)
       await runPlugin(ctx)
 
-      const probe = `
+      // check if the blob entries were successfully set on the build plugin
+      const blobEntries = await getBlobEntries(ctx)
+      expect(blobEntries.map(({ key }) => decodeBlobKey(key)).sort()).toEqual(
+        [
+          shouldHaveAppRouterNotFoundInPrerenderManifest() ? undefined : '/404',
+          isExperimentalPPRHardDeprecated() ? undefined : '/static-params/[id]',
+          shouldHaveAppRouterGlobalErrorInPrerenderManifest() ? '/_global-error' : undefined,
+          shouldHaveAppRouterNotFoundInPrerenderManifest() ? '/_not-found' : undefined,
+          '/dynamic-params/[id]',
+          '/index',
+          '/runtime-prefetchable',
+          '/static-params/1',
+          '/static-params/2',
+          '/static-params/[id]',
+          '404.html',
+          '500.html',
+        ].filter(Boolean),
+      )
+
+      // test the function call
+      const home = await invokeFunction(ctx)
+      expect(home.statusCode).toBe(200)
+      expect(load(home.body)('h1').text()).toBe('Home')
+
+      const res1 = await invokeFunction(ctx, { url: '/static-params/1' })
+      expect(res1.statusCode).toBe(200)
+      expect(load(res1.body)('h1').text()).toBe('Dynamic Page (static params): 1')
+
+      const res2 = await invokeFunction(ctx, { url: '/static-params/3' })
+      expect(res2.statusCode).toBe(200)
+      expect(load(res2.body)('h1').text()).toBe('Dynamic Page (static params): 3')
+
+      const res3 = await invokeFunction(ctx, { url: '/dynamic-params/123' })
+      expect(res3.statusCode).toBe(200)
+      // on this page, the `await params` is in a Suspense boundary
+      expect(load(res3.body)('body').text()).toContain('loading...')
+
+      const res4 = await invokeFunction(ctx, { url: '/runtime-prefetchable' })
+      expect(res4.statusCode).toBe(200)
+      // this page renders `use cache: private` content, which resolves on the server rather
+      // than leaving its Suspense fallback in the response
+      expect(load(res4.body)('body').text()).toContain('Search params: none')
+    })
+
+    describe('Cache Components + OpenTelemetry', () => {
+      // Next.js only installs its Cache Components tracer patch when the application has an
+      // `instrumentation.ts` exporting `register`, so an SDK registered by our Functions
+      // bootstrap is left unpatched. `ensureOtelTracerPatchedForCacheComponents` works around
+      // that by calling Next.js' own `afterRegistration()` - see the note on it in
+      // `src/run/next.cts`.
+      //
+      // That reaches into a private Next.js module, so if Next.js ever moves or reworks it we
+      // would silently stop patching. This calls our own function inside the built server
+      // handler - where `next` resolves to the version under test - and asserts it still has
+      // an effect.
+      test.skipIf(!hasCacheComponentsTracerPatch())<FixtureTestContext>(
+        'our tracer patching still takes effect',
+        async (ctx) => {
+          await createFixture('ppr', ctx)
+          await runPlugin(ctx)
+
+          const probe = `
         // Resolve @opentelemetry/api the way Next.js' extension does, so we read the provider
         // back from the same copy it patches. The API's compatibility check is asymmetric, so
         // going through a different copy can hand back a different provider.
@@ -152,43 +157,46 @@ describe('Cache Components + OpenTelemetry', () => {
         }
       `
 
-      // Runs in a child process because the runtime patches process globals (`Math.random`,
-      // `Date`, `console`) that other tests would otherwise inherit. The SDK is registered by
-      // a preload, so it is in place before the runtime is imported - `@netlify/otel` keeps
-      // its global tracer on a plain `globalThis` key, so the copy in the bundle finds it.
-      const { exitCode } = await execa('node', ['-e', probe], {
-        cwd: join(ctx.functionDist, SERVER_HANDLER_NAME),
-        env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
-      })
+          // Runs in a child process because the runtime patches process globals
+          // (`Math.random`, `Date`, `console`) that other tests would otherwise inherit. The
+          // SDK is registered by a preload, so it is in place before the runtime is imported -
+          // `@netlify/otel` keeps its global tracer on a plain `globalThis` key, so the copy in
+          // the bundle finds it.
+          const { exitCode } = await execa('node', ['-e', probe], {
+            cwd: join(ctx.functionDist, SERVER_HANDLER_NAME),
+            env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
+          })
 
-      expect(exitCode).toBe(0)
-    },
-  )
+          expect(exitCode).toBe(0)
+        },
+      )
 
-  // ...and this is what that patch buys us. Without it, generating a span id calls
-  // `Math.random()`, which Next.js treats as synchronous platform IO while prerendering and
-  // aborts the runtime prerender. The abort is swallowed, so the page still renders - it just
-  // silently loses the runtime prefetch payload that seeds the client segment cache.
-  test.skipIf(!hasPartialPrefetching())<FixtureTestContext>(
-    'runtime prefetch payload survives when an OpenTelemetry SDK is registered',
-    async (ctx) => {
-      await createFixture('ppr', ctx)
-      await runPlugin(ctx)
+      // ...and this is what that patch buys us. Without it, generating a span id calls
+      // `Math.random()`, which Next.js treats as synchronous platform IO while prerendering and
+      // aborts the runtime prerender. The abort is swallowed, so the page still renders - it
+      // just silently loses the runtime prefetch payload that seeds the client segment cache.
+      test.skipIf(!hasPartialPrefetching())<FixtureTestContext>(
+        'runtime prefetch payload survives when an OpenTelemetry SDK is registered',
+        async (ctx) => {
+          await createFixture('ppr', ctx)
+          await runPlugin(ctx)
 
-      const { invokeFunction: invokeWithOtel } = await loadSandboxedFunction(ctx, {
-        env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
-      })
+          const { invokeFunction: invokeWithOtel } = await loadSandboxedFunction(ctx, {
+            env: { NODE_OPTIONS: `--require ${OTEL_BOOTSTRAP}` },
+          })
 
-      const response = await invokeWithOtel({ url: '/runtime-prefetchable' })
+          const response = await invokeWithOtel({ url: '/runtime-prefetchable' })
 
-      expect(response.statusCode).toBe(200)
-      expect(
-        countOccurrences(getInlinedFlightPayload(response.body), 'cached-content'),
-        "'cached-content' to appear twice in the flight payload - once for the rendered page " +
-          'portion and once for the runtime prefetch portion that seeds the client segment ' +
-          'cache. Getting 1 means the runtime prerender aborted and only the rendered page ' +
-          'portion was emitted',
-      ).toBe(2)
-    },
-  )
-})
+          expect(response.statusCode).toBe(200)
+          expect(
+            countOccurrences(getInlinedFlightPayload(response.body), 'cached-content'),
+            "'cached-content' to appear twice in the flight payload - once for the rendered " +
+              'page portion and once for the runtime prefetch portion that seeds the client ' +
+              'segment cache. Getting 1 means the runtime prerender aborted and only the ' +
+              'rendered page portion was emitted',
+          ).toBe(2)
+        },
+      )
+    })
+  },
+)

--- a/tests/integration/ppr.test.ts
+++ b/tests/integration/ppr.test.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio'
+import { getLogger } from 'lambda-local'
+import { v4 } from 'uuid'
+import { beforeEach, expect, test, vi } from 'vitest'
+
+import { type FixtureTestContext } from '../utils/contexts.js'
+import { createFixture, invokeFunction, runPlugin } from '../utils/fixture.js'
+import {
+  decodeBlobKey,
+  generateRandomObjectID,
+  getBlobEntries,
+  startMockBlobStore,
+} from '../utils/helpers.js'
+import {
+  isExperimentalPPRHardDeprecated,
+  nextVersionSatisfies,
+  shouldHaveAppRouterGlobalErrorInPrerenderManifest,
+  shouldHaveAppRouterNotFoundInPrerenderManifest,
+} from '../utils/next-version-helpers.mjs'
+
+// Disable the verbose logging of the lambda-local runtime
+getLogger().level = 'alert'
+
+beforeEach<FixtureTestContext>(async (ctx) => {
+  // set for each test a new deployID and siteID
+  ctx.deployID = generateRandomObjectID()
+  ctx.siteID = v4()
+  vi.stubEnv('SITE_ID', ctx.siteID)
+  vi.stubEnv('DEPLOY_ID', ctx.deployID)
+  // hide debug logs in tests
+  vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+  await startMockBlobStore(ctx)
+})
+
+test.skipIf(
+  process.env.NEXT_VERSION !== 'canary' && nextVersionSatisfies('<16.0.0'),
+)<FixtureTestContext>('Test that a simple next app with PPR is working', async (ctx) => {
+  await createFixture('ppr', ctx)
+  await runPlugin(ctx)
+
+  // check if the blob entries were successfully set on the build plugin
+  const blobEntries = await getBlobEntries(ctx)
+  expect(blobEntries.map(({ key }) => decodeBlobKey(key)).sort()).toEqual(
+    [
+      shouldHaveAppRouterNotFoundInPrerenderManifest() ? undefined : '/404',
+      isExperimentalPPRHardDeprecated() ? undefined : '/static-params/[id]',
+      shouldHaveAppRouterGlobalErrorInPrerenderManifest() ? '/_global-error' : undefined,
+      shouldHaveAppRouterNotFoundInPrerenderManifest() ? '/_not-found' : undefined,
+      '/dynamic-params/[id]',
+      '/index',
+      '/static-params/1',
+      '/static-params/2',
+      '/static-params/[id]',
+      '404.html',
+      '500.html',
+    ].filter(Boolean),
+  )
+
+  // test the function call
+  const home = await invokeFunction(ctx)
+  expect(home.statusCode).toBe(200)
+  expect(load(home.body)('h1').text()).toBe('Home')
+
+  const res1 = await invokeFunction(ctx, { url: '/static-params/1' })
+  expect(res1.statusCode).toBe(200)
+  expect(load(res1.body)('h1').text()).toBe('Dynamic Page (static params): 1')
+
+  const res2 = await invokeFunction(ctx, { url: '/static-params/3' })
+  expect(res2.statusCode).toBe(200)
+  expect(load(res2.body)('h1').text()).toBe('Dynamic Page (static params): 3')
+
+  const res3 = await invokeFunction(ctx, { url: '/dynamic-params/123' })
+  expect(res3.statusCode).toBe(200)
+  // on this page, the `await params` is in a Suspense boundary
+  expect(load(res3.body)('body').text()).toContain('loading...')
+})

--- a/tests/integration/simple-app.test.ts
+++ b/tests/integration/simple-app.test.ts
@@ -38,9 +38,7 @@ import {
 } from '../utils/helpers.js'
 import {
   hasDefaultTurbopackBuilds,
-  isExperimentalPPRHardDeprecated,
   nextVersionSatisfies,
-  shouldHaveAppRouterGlobalErrorInPrerenderManifest,
   shouldHaveAppRouterNotFoundInPrerenderManifest,
   shouldHaveSlashIndexTagForIndexPage,
 } from '../utils/next-version-helpers.mjs'
@@ -437,49 +435,6 @@ test<FixtureTestContext>('rewrites to external addresses dont use compression', 
   expect(page.headers).not.toHaveProperty('transfer-encoding')
   expect(page.headers['content-encoding']).toBe('gzip')
   expect(gunzipSync(page.bodyBuffer).toString('utf-8')).toContain('<title>Example Domain</title>')
-})
-
-test.skipIf(
-  process.env.NEXT_VERSION !== 'canary' && nextVersionSatisfies('<16.0.0'),
-)<FixtureTestContext>('Test that a simple next app with PPR is working', async (ctx) => {
-  await createFixture('ppr', ctx)
-  await runPlugin(ctx)
-
-  // check if the blob entries were successfully set on the build plugin
-  const blobEntries = await getBlobEntries(ctx)
-  expect(blobEntries.map(({ key }) => decodeBlobKey(key)).sort()).toEqual(
-    [
-      shouldHaveAppRouterNotFoundInPrerenderManifest() ? undefined : '/404',
-      isExperimentalPPRHardDeprecated() ? undefined : '/static-params/[id]',
-      shouldHaveAppRouterGlobalErrorInPrerenderManifest() ? '/_global-error' : undefined,
-      shouldHaveAppRouterNotFoundInPrerenderManifest() ? '/_not-found' : undefined,
-      '/dynamic-params/[id]',
-      '/index',
-      '/static-params/1',
-      '/static-params/2',
-      '/static-params/[id]',
-      '404.html',
-      '500.html',
-    ].filter(Boolean),
-  )
-
-  // test the function call
-  const home = await invokeFunction(ctx)
-  expect(home.statusCode).toBe(200)
-  expect(load(home.body)('h1').text()).toBe('Home')
-
-  const res1 = await invokeFunction(ctx, { url: '/static-params/1' })
-  expect(res1.statusCode).toBe(200)
-  expect(load(res1.body)('h1').text()).toBe('Dynamic Page (static params): 1')
-
-  const res2 = await invokeFunction(ctx, { url: '/static-params/3' })
-  expect(res2.statusCode).toBe(200)
-  expect(load(res2.body)('h1').text()).toBe('Dynamic Page (static params): 3')
-
-  const res3 = await invokeFunction(ctx, { url: '/dynamic-params/123' })
-  expect(res3.statusCode).toBe(200)
-  // on this page, the `await params` is in a Suspense boundary
-  expect(load(res3.body)('body').text()).toContain('loading...')
 })
 
 // setup for this test only works with webpack builds due to usage of ` __non_webpack_require__` to avoid bundling a file

--- a/tests/utils/next-version-helpers.mjs
+++ b/tests/utils/next-version-helpers.mjs
@@ -38,6 +38,16 @@ export function shouldHaveAppRouterNotFoundInPrerenderManifest() {
   return nextVersionSatisfies(isNextCanary() ? '>=15.4.2-canary.33' : '>=15.5.0')
 }
 
+export function hasCacheComponentsTracerPatch() {
+  // https://github.com/vercel/next.js/pull/82350 added
+  // `server/lib/router-utils/instrumentation-node-extensions.ts`, which we call into
+  // ourselves - see `ensureOtelTracerPatchedForCacheComponents` in `src/run/next.cts`.
+
+  // The canary versions are out of band, as there stable/latest patch versions higher than base of canary versions without
+  // the change included
+  return nextVersionSatisfies(isNextCanary() ? '>=15.4.2-canary.31' : '>=15.5.0')
+}
+
 export function hasPartialPrefetching() {
   // https://github.com/vercel/next.js/pull/94448 added `export const prefetch = 'partial'`,
   // which is what makes Next.js inline a runtime prefetch payload into the initial HTML.

--- a/tests/utils/next-version-helpers.mjs
+++ b/tests/utils/next-version-helpers.mjs
@@ -38,6 +38,14 @@ export function shouldHaveAppRouterNotFoundInPrerenderManifest() {
   return nextVersionSatisfies(isNextCanary() ? '>=15.4.2-canary.33' : '>=15.5.0')
 }
 
+export function hasPartialPrefetching() {
+  // https://github.com/vercel/next.js/pull/94448 added `export const prefetch = 'partial'`,
+  // which is what makes Next.js inline a runtime prefetch payload into the initial HTML.
+
+  // Canary only so far, no stable release includes it yet.
+  return nextVersionSatisfies('>=16.3.0-canary.45')
+}
+
 export function shouldHaveAppRouterGlobalErrorInPrerenderManifest() {
   // https://github.com/vercel/next.js/pull/82444
 

--- a/tests/utils/otel-bootstrap.cjs
+++ b/tests/utils/otel-bootstrap.cjs
@@ -1,0 +1,21 @@
+// Registers an OpenTelemetry SDK the way Netlify's Functions bootstrap does: globally, and
+// outside the application's `instrumentation.ts` hook. Preloaded with `--require` so that
+// registration happens before the server handler is imported.
+//
+// Goes through `@netlify/otel`'s own `createTracerProvider` rather than registering a bare
+// `NodeTracerProvider`, because that is what also installs the global accessor that
+// `getTracer()` reads - and our runtime uses `getTracer()` to decide whether there is a
+// provider worth patching.
+const { createTracerProvider } = require('@netlify/otel/bootstrap')
+
+createTracerProvider({
+  serviceName: 'integration-test',
+  serviceVersion: '0.0.0',
+  deploymentEnvironment: 'test',
+  siteUrl: 'https://example.netlify.app',
+  siteId: 'test-site-id',
+  siteName: 'test-site',
+  // No span processors: nothing should be exported anywhere during tests. Span ids are still
+  // generated, which is all this needs to reproduce.
+  spanProcessors: [],
+})


### PR DESCRIPTION
<!-- Before opening a pull request, ensure you've read our contributing guidelines, https://github.com/opennextjs/opennextjs-netlify/blob/main/CONTRIBUTING.md. -->

## Description

Next.js only installs its Cache Components tracer patch when the app has an instrumentation.ts exporting register — that's the only place afterRegistration() is called. Our Functions bootstrap registers an OpenTelemetry SDK outside that hook, so on sites without an `instrumentation.ts` the tracer stays unpatched.

An unpatched tracer creates spans inside the active `workUnitAsyncStorage` context. Generating a span id calls `Math.random()`, which Next instruments under cacheComponents to treat as synchronous platform IO — seeing a work unit store, it aborts the surrounding prerender. Next's patch wraps `startSpan`/`startActiveSpan` in `workUnitAsyncStorage.exit()` so span creation happens outside that context; the id is still random, it just no longer registers as IO against the prerender.

The failure is silent: the page still renders, but the runtime-prefetch payload that seeds the client segment cache is dropped from the initial HTML, so navigations refetch content that should already have been seeded.

### Documentation

<!-- Where is this feature or API documented? Did you create an internal and/or external artifact to document this change? -->

## Tests

Added some integration test for behavior (inspired by setup used by one of Next.js repo e2e tests) and if patch still works correctly (and moved existing ppr related integration test to dedicated ppr test file)

This was originally found when running Next.js e2e test suite (fixes ~40 e2e test failures there)

## Relevant links (GitHub issues, etc.) or a picture of cute animal

<!-- Link to an issue that is fixed by this PR or related to this PR. -->
